### PR TITLE
fix(site): persist material ui css on first render

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -281,7 +281,10 @@ app.get('*', async (req, res, next) => {
     await Promise.delay(0);
     data.children = await ReactDOMServer.renderToString(rootComponent);
     const materialUICss = sheetsRegistry.toString();
-    data.styles = [{ id: 'css', cssText: [...css].join(materialUICss) }];
+    data.styles = [
+      { id: 'css', cssText: [...css].join('') },
+      { id: 'materialUI', cssText: materialUICss },
+    ];
 
     data.scripts = [assets.vendor.js];
     if (route.chunks) {


### PR DESCRIPTION
This fixes the bug where material ui css would disappear after the first page load in _production_ mode. I'm not exactly sure what's the root cause of the problem, but if anyone wants to take a look at it here's something to consider when tracking: if you set webpack clientConf [NODE_ENV](https://github.com/elmadev/elmaonline-site/blob/890047e2aa1d12f401a5b4973412567e57e8de71/tools/webpack.config.js#L322) to fixed value "development" the bug disappears in production, so it seems to have something to do specifically with creating the client bundle in production mode. I couldn't find any places where it would affect our code so maybe it's dependant on some external library or something.

Anyways, this circumvents the bug but isn't fixing the real problem.