### PR TITLE
Results fixes and battle pagination

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "query-string": "^5.0.1",
     "react": "16.4.1",
     "react-apollo": "^2.0.4",
-    "react-dom": "16.4.1",
+    "react-dom": "16.4.2",
     "react-dropzone": "^4.2.13",
     "react-jss": "^8.6.1",
     "react-moment": "^0.7.0",

--- a/src/components/BattleList/BattleList.js
+++ b/src/components/BattleList/BattleList.js
@@ -2,7 +2,7 @@ import React from 'react';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
 import { graphql, compose } from 'react-apollo';
 import PropTypes from 'prop-types';
-import { toServerTime } from 'utils';
+import { toServerTime, sortResults } from 'utils';
 import LocalTime from '../../components/LocalTime';
 import Link from '../../components/Link';
 import Time from '../../components/Time';
@@ -24,43 +24,46 @@ const BattleList = props => {
           <span>Players</span>
         </div>
         {!loading &&
-          getBattlesBetween.map(b => (
-            <Link key={b.BattleIndex} to={`battles/${b.BattleIndex}`}>
-              <span className={s.levelFileName}>
-                {b.LevelData && b.LevelData.LevelName}
-              </span>
-              <span className={s.designerName}>
-                {b.KuskiData.Kuski}{' '}
-                {b.KuskiData.TeamData && `[${b.KuskiData.TeamData.Team}]`}
-              </span>
-              <span className={s.winnerKuski}>
-                {b.Results.length > 0 ? b.Results[0].KuskiData.Kuski : null}{' '}
-                {b.Results.length > 0 &&
-                  b.Results[0].KuskiData.TeamData &&
-                  `[${b.Results[0].KuskiData.TeamData.Team}]`}
-              </span>
-              <span className={s.winnerTime}>
-                {b.Results.length > 0 ? (
-                  <Time time={b.Results[0].Time} />
-                ) : null}
-              </span>
-              <span className={s.battleStarted}>
-                <LocalTime date={b.Started} format="HH:mm:ss" parse="X" />
-              </span>
-              <span>
-                <div className={s.popularity}>
-                  <div
-                    title={b.Results.length}
-                    className={s.popularityBar}
-                    style={{
-                      width: `${b.Results.length / 20 * 100}%`,
-                      opacity: b.Results.length / 20 + 0.1,
-                    }}
-                  />
-                </div>
-              </span>
-            </Link>
-          ))}
+          getBattlesBetween.map(b => {
+            const sorted = [...b.Results].sort(sortResults);
+            return (
+              <Link key={b.BattleIndex} to={`battles/${b.BattleIndex}`}>
+                <span className={s.levelFileName}>
+                  {b.LevelData && b.LevelData.LevelName}
+                </span>
+                <span className={s.designerName}>
+                  {b.KuskiData.Kuski}{' '}
+                  {b.KuskiData.TeamData && `[${b.KuskiData.TeamData.Team}]`}
+                </span>
+                <span className={s.winnerKuski}>
+                  {b.Results.length > 0 ? sorted[0].KuskiData.Kuski : null}{' '}
+                  {b.Results.length > 0 &&
+                    sorted[0].KuskiData.TeamData &&
+                    `[${sorted[0].KuskiData.TeamData.Team}]`}
+                </span>
+                <span className={s.winnerTime}>
+                  {b.Results.length > 0 && (
+                    <Time time={sorted[0].Time} apples={sorted[0].Apples} />
+                  )}
+                </span>
+                <span className={s.battleStarted}>
+                  <LocalTime date={b.Started} format="HH:mm:ss" parse="X" />
+                </span>
+                <span>
+                  <div className={s.popularity}>
+                    <div
+                      title={b.Results.length}
+                      className={s.popularityBar}
+                      style={{
+                        width: `${b.Results.length / 20 * 100}%`,
+                        opacity: b.Results.length / 20 + 0.1,
+                      }}
+                    />
+                  </div>
+                </span>
+              </Link>
+            );
+          })}
       </div>
       {loading && <Loading />}
     </div>

--- a/src/components/BattleList/battles.graphql
+++ b/src/components/BattleList/battles.graphql
@@ -25,6 +25,8 @@ query Battles($start: String, $end: String) {
       KuskiIndex
       KuskiIndex2
       Time
+      Apples
+      TimeIndex
       KuskiData {
         Kuski
         TeamData {

--- a/src/components/Layout/Layout.css
+++ b/src/components/Layout/Layout.css
@@ -218,3 +218,7 @@ h3 {
 h2 {
   text-transform: uppercase;
 }
+
+*:focus {
+  outline: 0;
+}

--- a/src/components/SideBar/SideBar.css
+++ b/src/components/SideBar/SideBar.css
@@ -62,7 +62,7 @@
 .content a {
   color: #c3c3c3;
   display: block;
-  padding: 15px;
+  padding: 10px 15px;
   text-decoration: none;
 }
 

--- a/src/components/Time/Time.js
+++ b/src/components/Time/Time.js
@@ -7,12 +7,17 @@ const hundredsValues = [100, 5999, 6000, 2];
 class Time extends React.Component {
   static propTypes = {
     time: PropTypes.number.isRequired,
+    apples: PropTypes.number,
     thousands: PropTypes.bool,
   };
   static defaultProps = {
     thousands: false,
+    apples: 0,
   };
   formatTime = time => {
+    if (time === 0) {
+      return `${this.props.apples} apple${this.props.apples !== 1 ? `s` : ``}`;
+    }
     let values = hundredsValues;
     if (this.props.thousands) {
       values = thousandsValues;
@@ -25,10 +30,6 @@ class Time extends React.Component {
 
     if (time > values[1]) {
       return `${Math.floor(time / values[2])}:${string}`;
-    }
-
-    if (time === 0) {
-      return '0 apples';
     }
 
     return string;

--- a/src/components/variables.css
+++ b/src/components/variables.css
@@ -20,7 +20,7 @@
 
   --max-content-width: 100%;
   --top-bar-height: 50px;
-  --side-bar-width: 300px;
+  --side-bar-width: 250px;
 
   /*
    * Media queries breakpoints

--- a/src/routes/battle/Battle.js
+++ b/src/routes/battle/Battle.js
@@ -105,14 +105,14 @@ class Battle extends React.Component {
                   <TableRow>
                     <TableCell
                       style={{
-                        width: '.5rem',
+                        width: 1,
                       }}
                     >
                       #
                     </TableCell>
                     <TableCell
                       style={{
-                        width: '10rem',
+                        width: 200,
                       }}
                     >
                       Kuski

--- a/src/routes/battle/Battle.js
+++ b/src/routes/battle/Battle.js
@@ -13,6 +13,7 @@ import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
 import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import Paper from '@material-ui/core/Paper';
+import { sortResults } from 'utils';
 import s from './Battle.css';
 import battleQuery from './battle.graphql';
 import Recplayer from '../../components/Recplayer';
@@ -121,19 +122,21 @@ class Battle extends React.Component {
                   </TableRow>
                 </TableHead>
                 <TableBody>
-                  {getBattle.Results.map((r, i) => (
-                    <TableRow key={r.KuskiIndex}>
-                      <TableCell>{i + 1}.</TableCell>
-                      <TableCell>
-                        {r.KuskiData.Kuski}{' '}
-                        {r.KuskiData.TeamData &&
-                          `[${r.KuskiData.TeamData.Team}]`}
-                      </TableCell>
-                      <TableCell>
-                        <Time time={r.Time} />
-                      </TableCell>
-                    </TableRow>
-                  ))}
+                  {[...getBattle.Results]
+                    .sort(sortResults(getBattle.BattleType))
+                    .map((r, i) => (
+                      <TableRow key={r.KuskiIndex}>
+                        <TableCell>{i + 1}.</TableCell>
+                        <TableCell>
+                          {r.KuskiData.Kuski}{' '}
+                          {r.KuskiData.TeamData &&
+                            `[${r.KuskiData.TeamData.Team}]`}
+                        </TableCell>
+                        <TableCell>
+                          <Time time={r.Time} apples={r.Apples} />
+                        </TableCell>
+                      </TableRow>
+                    ))}
                 </TableBody>
               </Table>
             )}

--- a/src/routes/battle/battle.graphql
+++ b/src/routes/battle/battle.graphql
@@ -19,7 +19,9 @@ query Battletime($BattleIndex: Int!) {
     }
     Results {
       Time
+      TimeIndex
       KuskiIndex
+      Apples
       KuskiData {
         Kuski
         TeamData {

--- a/src/routes/kuski/Kuski.js
+++ b/src/routes/kuski/Kuski.js
@@ -3,51 +3,9 @@ import { graphql, compose } from 'react-apollo';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
 import PropTypes from 'prop-types';
 import kuskiQuery from './kuski.graphql';
-import battlesQuery from './battles.graphql';
-import Link from '../../components/Link';
-import Time from '../../components/Time';
-import Loading from '../../components/Loading';
 import Flag from '../../components/Flag';
-import LocalTime from '../../components/LocalTime';
+import PlayedBattles from './PlayedBattles';
 import s from './Kuski.css';
-
-const RecentBattles = compose(
-  withStyles(s),
-  graphql(battlesQuery, {
-    options: ownProps => ({
-      variables: {
-        KuskiIndex: ownProps.KuskiIndex,
-      },
-    }),
-  }),
-)(props => {
-  if (!props.data.getBattlesByKuski) return <Loading />;
-
-  return props.data.getBattlesByKuski.map(b => (
-    <Link to={`/battles/${b.BattleIndex}`} key={b.BattleIndex}>
-      <span>{b.LevelData && b.LevelData.LevelName}</span>
-      <span>
-        {b.KuskiData.Kuski}{' '}
-        {b.KuskiData.TeamData && `[${b.KuskiData.TeamData.Team}]`}
-      </span>
-      <span>
-        {b.Results.length > 0 ? b.Results[0].KuskiData.Kuski : null}{' '}
-        {b.Results.length > 0 &&
-          b.Results[0].KuskiData.TeamData &&
-          `[${b.Results[0].KuskiData.TeamData.Team}]`}
-      </span>
-      <span>
-        {b.Results.length > 0 ? <Time time={b.Results[0].Time} /> : null}
-      </span>
-      <span>
-        {b.Results.findIndex(r => r.KuskiIndex === props.KuskiIndex) + 1}
-      </span>
-      <span>
-        <LocalTime date={b.Started} format="DD.MM.YYYY HH:mm:ss" parse="X" />
-      </span>
-    </Link>
-  ));
-});
 
 class Kuski extends React.Component {
   render() {
@@ -92,7 +50,7 @@ class Kuski extends React.Component {
             </div>
           </div>
         </div>
-        <h2>Latest battles</h2>
+        <h2>Played battles</h2>
         <div style={{ maxWidth: '100%', overflow: 'auto' }}>
           <div className={s.recentBattles}>
             <div className={s.recentBattlesHead}>
@@ -103,7 +61,7 @@ class Kuski extends React.Component {
               <span>Placement</span>
               <span>Started</span>
             </div>
-            <RecentBattles KuskiIndex={getKuskiByName.KuskiIndex} />
+            <PlayedBattles KuskiIndex={getKuskiByName.KuskiIndex} />
           </div>
         </div>
       </div>

--- a/src/routes/kuski/PlayedBattles.js
+++ b/src/routes/kuski/PlayedBattles.js
@@ -1,0 +1,95 @@
+import React from 'react';
+import { graphql, compose } from 'react-apollo';
+import TablePagination from '@material-ui/core/TablePagination';
+import PropTypes from 'prop-types';
+import Time from '../../components/Time';
+import Link from '../../components/Link';
+import LocalTime from '../../components/LocalTime';
+import battlesQuery from './battles.graphql';
+
+class PlayedBattles extends React.Component {
+  render() {
+    if (!this.props.data.getBattlesByKuski) return null;
+    return (
+      <React.Fragment>
+        {this.props.data.getBattlesByKuski.rows.map(b => (
+          <Link to={`/battles/${b.BattleIndex}`} key={b.BattleIndex}>
+            <span>{b.LevelData && b.LevelData.LevelName}</span>
+            <span>
+              {b.KuskiData.Kuski}{' '}
+              {b.KuskiData.TeamData && `[${b.KuskiData.TeamData.Team}]`}
+            </span>
+            <span>
+              {b.Results.length > 0 ? b.Results[0].KuskiData.Kuski : null}{' '}
+              {b.Results.length > 0 &&
+                b.Results[0].KuskiData.TeamData &&
+                `[${b.Results[0].KuskiData.TeamData.Team}]`}
+            </span>
+            <span>
+              {b.Results.length > 0 ? <Time time={b.Results[0].Time} /> : null}
+            </span>
+            <span>
+              {b.Results.findIndex(
+                r => r.KuskiIndex === this.props.KuskiIndex,
+              ) + 1}
+            </span>
+            <span>
+              <LocalTime
+                date={b.Started}
+                format="DD.MM.YYYY HH:mm:ss"
+                parse="X"
+              />
+            </span>
+          </Link>
+        ))}
+        <TablePagination
+          component="div"
+          count={this.props.data.getBattlesByKuski.total}
+          rowsPerPage={25}
+          page={this.props.data.getBattlesByKuski.page}
+          backIconButtonProps={{
+            'aria-label': 'Previous Page',
+          }}
+          nextIconButtonProps={{
+            'aria-label': 'Next Page',
+          }}
+          onChangePage={(e, page) => {
+            this.props.data.fetchMore({
+              variables: {
+                Page: page,
+              },
+              updateQuery: (prev, { fetchMoreResult }) => {
+                if (!fetchMoreResult) return prev;
+                return Object.assign({}, prev, {
+                  getBattlesByKuski: {
+                    __typename: prev.getBattlesByKuski.__typename,
+                    total: fetchMoreResult.getBattlesByKuski.total,
+                    page: fetchMoreResult.getBattlesByKuski.page,
+                    rows: [...fetchMoreResult.getBattlesByKuski.rows],
+                  },
+                });
+              },
+            });
+          }}
+          rowsPerPageOptions={[]}
+        />
+      </React.Fragment>
+    );
+  }
+}
+
+PlayedBattles.propTypes = {
+  data: PropTypes.shape.isRequired,
+  KuskiIndex: PropTypes.number.isRequired,
+};
+
+export default compose(
+  graphql(battlesQuery, {
+    options: ownProps => ({
+      variables: {
+        KuskiIndex: ownProps.KuskiIndex,
+        Page: ownProps.Page || 0,
+      },
+    }),
+  }),
+)(PlayedBattles);

--- a/src/routes/kuski/battles.graphql
+++ b/src/routes/kuski/battles.graphql
@@ -1,34 +1,38 @@
-query getBattlesByKuski($KuskiIndex: Int!) {
-  getBattlesByKuski(KuskiIndex: $KuskiIndex) {
-    BattleIndex
-    KuskiIndex
-    LevelIndex
-    BattleType
-    Started
-    Duration
-    InQueue
-    Aborted
-    Finished
-    KuskiData {
-      KuskiIndex
-      Kuski
-      TeamData {
-        Team
-      }
-    }
-    LevelData {
-      LevelName
-    }
-    Results {
-      BattleTimeIndex
+query getBattlesByKuski($KuskiIndex: Int!, $Page: Int!) {
+  getBattlesByKuski(KuskiIndex: $KuskiIndex, Page: $Page) {
+    total
+    page
+    rows {
       BattleIndex
       KuskiIndex
-      KuskiIndex2
-      Time
+      LevelIndex
+      BattleType
+      Started
+      Duration
+      InQueue
+      Aborted
+      Finished
       KuskiData {
+        KuskiIndex
         Kuski
         TeamData {
           Team
+        }
+      }
+      LevelData {
+        LevelName
+      }
+      Results {
+        BattleTimeIndex
+        BattleIndex
+        KuskiIndex
+        KuskiIndex2
+        Time
+        KuskiData {
+          Kuski
+          TeamData {
+            Team
+          }
         }
       }
     }

--- a/src/routes/kuski/battles.graphql
+++ b/src/routes/kuski/battles.graphql
@@ -24,10 +24,12 @@ query getBattlesByKuski($KuskiIndex: Int!, $Page: Int!) {
       }
       Results {
         BattleTimeIndex
+        TimeIndex
         BattleIndex
         KuskiIndex
         KuskiIndex2
         Time
+        Apples
         KuskiData {
           Kuski
           TeamData {

--- a/src/routes/level/Level.js
+++ b/src/routes/level/Level.js
@@ -23,14 +23,14 @@ const TimeTable = withStyles(s)(({ data }) => (
         <TableRow>
           <TableCell
             style={{
-              width: '1px',
+              width: 1,
             }}
           >
             #
           </TableCell>
           <TableCell
             style={{
-              width: '6rem',
+              width: 200,
             }}
           >
             Kuski

--- a/src/utils.js
+++ b/src/utils.js
@@ -15,5 +15,19 @@ const toLocalTime = (date, parse) =>
       'America/Los_Angeles',
     )
     .tz(moment.tz.guess());
+const sortResults = battleType => (a, b) => {
+  if (a.Time === 0) {
+    if (b.Time !== 0) return 1;
 
-export { toServerTime, toLocalTime };
+    const d = b.Apples - a.Apples;
+    return d === 0 ? a.TimeIndex - b.TimeIndex : d;
+  }
+  const c =
+    battleType === 'SL' || battleType === 'SR'
+      ? b.Time - a.Time
+      : a.Time - b.Time;
+
+  return c === 0 ? a.TimeIndex - c.TimeIndex : c;
+};
+
+export { toServerTime, toLocalTime, sortResults };

--- a/yarn.lock
+++ b/yarn.lock
@@ -8912,9 +8912,10 @@ react-dev-utils@^4.2.1:
     strip-ansi "3.0.1"
     text-table "0.2.0"
 
-react-dom@16.4.1:
-  version "16.4.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.4.1.tgz#7f8b0223b3a5fbe205116c56deb85de32685dad6"
+react-dom@16.4.2:
+  version "16.4.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.4.2.tgz#4afed569689f2c561d2b8da0b819669c38a0bda4"
+  integrity sha512-Usl73nQqzvmJN+89r97zmeUpQDKDlh58eX6Hbs/ERdDHzeBzWy+ENk7fsGQ+5KxArV1iOFPT46/VneklK9zoWw==
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"


### PR DESCRIPTION
Sorting results work for some battle types, but probably not for certain special types such as flag tag, speed and finish count; those still need to be _sorted out_. Also the result display logic needs some work on those battle types. Apple results should be displayed correctly.

Also the pagination of battles on kuski page is included, though a separate pagination component should be created instead of using the terrible mui one which does not allow user to jump to a certain page directly.