### PR TITLE
fix(battlelist): fix display of queued and aborted battles

### DIFF
--- a/src/components/BattleList/BattleList.js
+++ b/src/components/BattleList/BattleList.js
@@ -36,10 +36,15 @@ const BattleList = props => {
                   {b.KuskiData.TeamData && `[${b.KuskiData.TeamData.Team}]`}
                 </span>
                 <span className={s.winnerKuski}>
-                  {b.Results.length > 0 ? sorted[0].KuskiData.Kuski : null}{' '}
-                  {b.Results.length > 0 &&
-                    sorted[0].KuskiData.TeamData &&
-                    `[${sorted[0].KuskiData.TeamData.Team}]`}
+                  {b.InQueue === 0 && b.Aborted === 0 && b.Finished === 0
+                    ? 'Ongoing'
+                    : b.Aborted === 1 ? 'Aborted'
+                    : b.InQueue === 1 ? 'Queued'
+                    : <div>{b.Results.length > 0 ? sorted[0].KuskiData.Kuski : null}{' '}
+                      {b.Results.length > 0 &&
+                        sorted[0].KuskiData.TeamData &&
+                        `[${sorted[0].KuskiData.TeamData.Team}]`}</div>
+                  }
                 </span>
                 <span className={s.winnerTime}>
                   {b.Results.length > 0 && (

--- a/src/data/graphql/Database/battle/GetBattles.js
+++ b/src/data/graphql/Database/battle/GetBattles.js
@@ -195,6 +195,9 @@ export const resolvers = {
           'LevelIndex',
           'Started',
           'Duration',
+          'Aborted',
+          'InQueue',
+          'Finished',
         ],
         limit: 100,
         include: [

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -57,9 +57,7 @@ class Home extends React.Component {
 
   render() {
     const { data: { loading, getBattles, getReplays, refetch } } = this.props; // deconstruct this.props here to get some nicer sounding variable names
-    const battleList = loading
-      ? null
-      : getBattles.filter(b => b.Aborted === 0).slice(0, 25);
+    const battleList = loading ? null : getBattles.slice(0, 25); // : getBattles.filter(b => b.Aborted === 0).slice(0, 25);
     const currentBattle = loading
       ? null
       : getBattles.filter(
@@ -107,16 +105,26 @@ class Home extends React.Component {
                           }}
                         >
                           <TableCell>
-                            {i.InQueue === 1 ? (
-                              'Queued'
-                            ) : (
+                            {i.Aborted === 1 ? (
                               <Link to={`/battles/${i.BattleIndex}`}>
-                                <LocalTime
-                                  date={i.Started}
-                                  format="HH:mm:ss"
-                                  parse="X"
-                                />
+                                Aborted
                               </Link>
+                            ) : (
+                              [
+                                i.InQueue === 1 ? (
+                                  <Link to={`/battles/${i.BattleIndex}`}>
+                                    Queued
+                                  </Link>
+                                ) : (
+                                  <Link to={`/battles/${i.BattleIndex}`}>
+                                    <LocalTime
+                                      date={i.Started}
+                                      format="HH:mm:ss"
+                                      parse="X"
+                                    />
+                                  </Link>
+                                ),
+                              ]
                             )}
                           </TableCell>
                           <TableCell>


### PR DESCRIPTION
Queued and aborted battles have "Queued" or "Aborted" displayed in the Winner column.