### PR TITLE
Fix remembering filters when navigating to a different rec in the same level

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -93,6 +93,9 @@ module.exports = {
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prefer-stateless-function.md
     'react/prefer-stateless-function': 'off',
 
+    // https://github.com/airbnb/javascript/issues/684#issuecomment-381674576
+    'react/no-did-mount-set-state': 'off',
+
     // ESLint plugin for prettier formatting
     // https://github.com/prettier/eslint-plugin-prettier
     'prettier/prettier': 'error',

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "pretty-error": "^2.1.1",
     "prop-types": "^15.6.0",
     "query-string": "^5.0.1",
+    "querystring": "^0.2.0",
     "react": "16.4.1",
     "react-apollo": "^2.0.4",
     "react-dom": "16.4.2",

--- a/src/components/RecList/RecList.js
+++ b/src/components/RecList/RecList.js
@@ -8,10 +8,12 @@ import TableCell from '@material-ui/core/TableCell';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 import Checkbox from '@material-ui/core/Checkbox';
+import querystring from 'querystring';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import recListQuery from './recList.graphql';
 import RecListItem from '../RecListItem';
 import history from '../../history';
+import historyRefresh from '../../historyRefresh';
 
 class RecList extends React.Component {
   static propTypes = {
@@ -32,27 +34,47 @@ class RecList extends React.Component {
         }),
       ),
     }).isRequired,
-    openReplay: PropTypes.func,
   };
 
-  static defaultProps = {
-    openReplay: null,
-  };
+  constructor(props) {
+    super(props);
 
-  state = {
-    showTAS: false,
-    showDNF: false,
-    showBug: false,
-    showNitro: false,
-  };
+    this.state = {
+      showTAS: false,
+      showDNF: false,
+      showBug: false,
+      showNitro: false,
+    };
+  }
+
+  componentDidMount() {
+    const queryParams = querystring.parse(window.location.search.substring(1));
+    this.setState({
+      showTAS: queryParams.showTAS === 'true',
+      showDNF: queryParams.showDNF === 'true',
+      showBug: queryParams.showBug === 'true',
+      showNitro: queryParams.showNitro === 'true',
+    });
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    return nextState !== this.state;
+  }
+
+  onFilterChange(id) {
+    const newState = { ...this.state };
+    newState[id] = !newState[id];
+    this.setState(() => newState);
+    history.replace({
+      search: `?${querystring.stringify(newState)}`,
+    });
+  }
 
   handleOpenReplay(uuid) {
-    const { openReplay } = this.props;
-    if (openReplay) {
-      openReplay(uuid);
-    } else {
-      history.push(`/r/${uuid}`);
-    }
+    historyRefresh.push({
+      pathname: `/r/${uuid}`,
+      search: `?${querystring.stringify(this.state)}`,
+    });
   }
 
   render() {
@@ -81,7 +103,7 @@ class RecList extends React.Component {
             control={
               <Checkbox
                 checked={this.state.showTAS}
-                onChange={() => this.setState({ showTAS: !showTAS })}
+                onChange={() => this.onFilterChange('showTAS')}
                 value="ShowTAS"
                 color="primary"
               />
@@ -92,7 +114,7 @@ class RecList extends React.Component {
             control={
               <Checkbox
                 checked={this.state.showDNF}
-                onChange={() => this.setState({ showDNF: !showDNF })}
+                onChange={() => this.onFilterChange('showDNF')}
                 value="ShowDNF"
                 color="primary"
               />
@@ -105,7 +127,7 @@ class RecList extends React.Component {
             control={
               <Checkbox
                 checked={this.state.showBug}
-                onChange={() => this.setState({ showBug: !showBug })}
+                onChange={() => this.onFilterChange('showBug')}
                 value="showBug"
                 color="primary"
               />
@@ -116,7 +138,7 @@ class RecList extends React.Component {
             control={
               <Checkbox
                 checked={this.state.showNitro}
-                onChange={() => this.setState({ showNitro: !showNitro })}
+                onChange={() => this.onFilterChange('showNitro')}
                 value="showNitro"
                 color="primary"
               />

--- a/src/routes/level/Level.js
+++ b/src/routes/level/Level.js
@@ -26,7 +26,6 @@ import Loading from '../../components/Loading';
 import Time from '../../components/Time';
 import Link from '../../components/Link';
 import LocalTime from '../../components/LocalTime';
-import historyRefresh from '../../historyRefresh';
 
 const TimeTable = withStyles(s)(({ data }) => (
   <div>
@@ -212,10 +211,7 @@ class Level extends React.Component {
                 <Typography variant="body2">Replays in level</Typography>
               </ExpansionPanelSummary>
               <ExpansionPanelDetails style={{ flexDirection: 'column' }}>
-                <RecList
-                  LevelIndex={this.props.LevelIndex}
-                  openReplay={uuid => historyRefresh.push(`/r/${uuid}`)}
-                />
+                <RecList LevelIndex={this.props.LevelIndex} />
               </ExpansionPanelDetails>
             </ExpansionPanel>
           </div>

--- a/src/routes/replay/Replay.js
+++ b/src/routes/replay/Replay.js
@@ -16,7 +16,6 @@ import { Level } from '../../components/Names';
 import Time from '../../components/Time';
 import Link from '../../components/Link';
 import RecList from '../../components/RecList';
-import historyRefresh from '../../historyRefresh';
 
 class Replay extends React.Component {
   static propTypes = {
@@ -120,10 +119,7 @@ class Replay extends React.Component {
                 <Typography variant="body2">Other replays in level</Typography>
               </ExpansionPanelSummary>
               <ExpansionPanelDetails style={{ flexDirection: 'column' }}>
-                <RecList
-                  LevelIndex={getReplayByUuid.LevelIndex}
-                  openReplay={uuid => historyRefresh.push(`/r/${uuid}`)}
-                />
+                <RecList LevelIndex={getReplayByUuid.LevelIndex} />
               </ExpansionPanelDetails>
             </ExpansionPanel>
           </div>


### PR DESCRIPTION
Store filters into query params.

Fixes https://github.com/elmadev/elmaonline-site/issues/110