### PR TITLE
feat(site): limited display of queued, ongoing and aborted battles

### DIFF
--- a/src/components/BattleList/BattleList.js
+++ b/src/components/BattleList/BattleList.js
@@ -2,7 +2,12 @@ import React from 'react';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
 import { graphql, compose } from 'react-apollo';
 import PropTypes from 'prop-types';
-import { toServerTime, sortResults } from 'utils';
+import {
+  toServerTime,
+  sortResults,
+  battleStatus,
+  battleStatusBgColor,
+} from 'utils';
 import LocalTime from '../../components/LocalTime';
 import Link from '../../components/Link';
 import Time from '../../components/Time';
@@ -28,21 +33,12 @@ const BattleList = props => {
         {getBattlesBetween &&
           getBattlesBetween.map(b => {
             const sorted = [...b.Results].sort(sortResults);
-            let winnerKuski;
-            if (b.InQueue === 0 && b.Aborted === 0 && b.Finished === 0) {
-              winnerKuski = 'Ongoing';
-            }
-            if (b.Aborted === 1) {
-              winnerKuski = 'Aborted';
-            }
-            if (b.Aborted === 0 && b.InQueue === 1) {
-              winnerKuski = 'Queued';
-            }
-            if (b.Finished === 1 && b.Results.length > 0) {
-              winnerKuski = <Kuski kuskiData={sorted[0].KuskiData} team flag />;
-            }
             return (
-              <Link key={b.BattleIndex} to={`battles/${b.BattleIndex}`}>
+              <Link
+                key={b.BattleIndex}
+                to={`battles/${b.BattleIndex}`}
+                style={{ backgroundColor: battleStatusBgColor(b) }}
+              >
                 <span className={s.type}>
                   {b.Duration} min <BattleType type={b.BattleType} />
                 </span>
@@ -52,7 +48,13 @@ const BattleList = props => {
                 <span className={s.levelFileName}>
                   {b.LevelData && b.LevelData.LevelName}
                 </span>
-                <span className={s.winnerKuski}> {winnerKuski} </span>
+                <span className={s.winnerKuski}>
+                  {b.Finished === 1 && b.Results.length > 0 ? (
+                    <Kuski kuskiData={sorted[0].KuskiData} team flag />
+                  ) : (
+                    battleStatus(b)
+                  )}
+                </span>
                 <span className={s.winnerTime}>
                   {b.Results.length > 0 && (
                     <Time time={sorted[0].Time} apples={sorted[0].Apples} />

--- a/src/data/graphql/Database/battle/GetBattles.js
+++ b/src/data/graphql/Database/battle/GetBattles.js
@@ -38,23 +38,18 @@ export const queries = [
   `
   # Retrieves all battles stored in the database
   getBattles: [DatabaseBattle]
-
+  
+  # Retrieves paginated battles for a particular kuski
+  getBattlesByKuski(KuskiIndex: Int!, Page: Int!): Pagination
+  
   # Retrieves all battles between two dates
   getBattlesBetween(start: String, end: String): [DatabaseBattle]
-
+  
   # Retrieves a single battle from the database
-  getBattle(
-    # The battle's id
-    BattleIndex: Int!
-  ): DatabaseBattle
-
+  getBattle(BattleIndex: Int!): DatabaseBattle
+  
   # Retrieves all battles in a specific level
-  getBattlesForLevel(
-    # The level id
-    LevelIndex: Int!
-  ): [DatabaseBattle]
-
-  getBattlesByKuski(KuskiIndex: Int!, Page: Int!): Pagination
+  getBattlesForLevel(LevelIndex: Int!): [DatabaseBattle]
 `,
 ];
 

--- a/src/data/graphql/Database/battle/GetBattles.js
+++ b/src/data/graphql/Database/battle/GetBattles.js
@@ -94,6 +94,28 @@ export const resolvers = {
               },
             ],
           },
+          {
+            model: Level,
+            attributes: ['LevelName'],
+            as: 'LevelData',
+          },
+          {
+            model: Battletime,
+            as: 'Results',
+            include: [
+              {
+                model: Kuski,
+                attributes: ['Kuski', 'Country'],
+                as: 'KuskiData',
+                include: [
+                  {
+                    model: Team,
+                    as: 'TeamData',
+                  },
+                ],
+              },
+            ],
+          },
         ],
         order: [['BattleIndex', 'DESC']],
       });
@@ -255,8 +277,11 @@ export const resolvers = {
           'Started',
           'BattleType',
           'Duration',
+          'Aborted',
+          'InQueue',
+          'Finished',
         ],
-        where: { BattleIndex, Finished: 1 },
+        where: { BattleIndex /* Finished: 1 */ },
         include: [
           {
             model: Kuski,
@@ -316,6 +341,23 @@ export const resolvers = {
             model: Level,
             attributes: ['LevelName'],
             as: 'LevelData',
+          },
+          {
+            model: Battletime,
+            as: 'Results',
+            include: [
+              {
+                model: Kuski,
+                attributes: ['Kuski', 'Country'],
+                as: 'KuskiData',
+                include: [
+                  {
+                    model: Team,
+                    as: 'TeamData',
+                  },
+                ],
+              },
+            ],
           },
         ],
         order: [['BattleIndex', 'DESC']],

--- a/src/data/graphql/Database/battle/GetBattletime.js
+++ b/src/data/graphql/Database/battle/GetBattletime.js
@@ -1,4 +1,4 @@
-import { Battletime, Kuski, Team, AllFinished } from 'data/models'; // import the data model
+import { Battle, Battletime, Kuski, Team, AllFinished } from 'data/models'; // import the data model
 
 export const schema = [
   `
@@ -30,42 +30,60 @@ export const queries = [
 export const resolvers = {
   RootQuery: {
     async getBattletime(parent, { BattleIndex }) {
-      const battletime = await Battletime.findAll({
+      const battleStatus = await Battle.findAll({
+        attributes: ['Finished'],
         where: { BattleIndex },
-        include: [
-          {
-            model: Kuski,
-            attributes: ['Kuski', 'Country'],
-            as: 'KuskiData',
-            include: [
-              {
-                model: Team,
-                as: 'TeamData',
-              },
-            ],
-          },
-        ],
       });
+      let battletime;
+      if (battleStatus[0].dataValues.Finished === 1) {
+        battletime = await Battletime.findAll({
+          where: { BattleIndex },
+          include: [
+            {
+              model: Kuski,
+              attributes: ['Kuski', 'Country'],
+              as: 'KuskiData',
+              include: [
+                {
+                  model: Team,
+                  as: 'TeamData',
+                },
+              ],
+            },
+          ],
+        });
+      } else {
+        battletime = [];
+      }
       return battletime;
     },
     async getAllBattleTimes(parent, { BattleIndex }) {
-      const times = await AllFinished.findAll({
+      const battleStatus = await Battle.findAll({
+        attributes: ['Finished'],
         where: { BattleIndex },
-        order: [['TimeIndex', 'ASC']],
-        include: [
-          {
-            model: Kuski,
-            as: 'KuskiData',
-            attributes: ['Kuski', 'Country'],
-            include: [
-              {
-                model: Team,
-                as: 'TeamData',
-              },
-            ],
-          },
-        ],
       });
+      let times;
+      if (battleStatus[0].dataValues.Finished === 1) {
+        times = await AllFinished.findAll({
+          where: { BattleIndex },
+          order: [['TimeIndex', 'ASC']],
+          include: [
+            {
+              model: Kuski,
+              as: 'KuskiData',
+              attributes: ['Kuski', 'Country'],
+              include: [
+                {
+                  model: Team,
+                  as: 'TeamData',
+                },
+              ],
+            },
+          ],
+        });
+      } else {
+        times = [];
+      }
       return times;
     },
   },

--- a/src/routes/battle/Battle.css
+++ b/src/routes/battle/Battle.css
@@ -5,7 +5,7 @@
 }
 
 .playerContainer {
-  width: 70%;
+  width: 60%;
   float: left;
   padding: 7px;
   box-sizing: border-box;
@@ -21,13 +21,13 @@
 
 .rightBarContainer {
   float: right;
-  width: 30%;
+  width: 40%;
   padding: 7px;
   box-sizing: border-box;
 }
 
 .levelStatsContainer {
-  width: 70%;
+  width: 60%;
   float: left;
   padding: 7px;
   box-sizing: border-box;

--- a/src/routes/battle/Battle.js
+++ b/src/routes/battle/Battle.js
@@ -44,17 +44,21 @@ class Battle extends React.Component {
 
     return (
       <div className={s.root}>
-        <div className={s.playerContainer}>
-          <div className={s.player}>
-            {isWindow && (
-              <Recplayer
-                rec={`/dl/battlereplay/${BattleIndex}`}
-                lev={`/dl/level/${getBattle.LevelIndex}`}
-                controls
-              />
-            )}
+        {
+          <div className={s.playerContainer}>
+            <div className={s.player}>
+              {isWindow &&
+                (getBattle.InQueue === 0 ||
+                  (getBattle.Aborted === 1 && getBattle.InQueue === 1)) && (
+                  <Recplayer
+                    rec={`/dl/battlereplay/${BattleIndex}`}
+                    lev={`/dl/level/${getBattle.LevelIndex}`}
+                    controls
+                  />
+                )}
+            </div>
           </div>
-        </div>
+        }
         <div className={s.rightBarContainer}>
           <div className={s.chatContainer}>
             <ExpansionPanel defaultExpanded>
@@ -129,19 +133,23 @@ class Battle extends React.Component {
                 </ExpansionPanelDetails>
               </ExpansionPanel>
             )}
-            <ExpansionPanel defaultExpanded>
-              <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
-                <Typography variant="body2">Chat</Typography>
-              </ExpansionPanelSummary>
-              <ExpansionPanelDetails>
-                <Chat
-                  start={getBattle.Started}
-                  end={
-                    Number(getBattle.Started) + Number(getBattle.Duration * 60)
-                  }
-                />
-              </ExpansionPanelDetails>
-            </ExpansionPanel>
+            {(getBattle.InQueue === 0 ||
+              (getBattle.Aborted === 1 && getBattle.InQueue === 1)) && (
+              <ExpansionPanel defaultExpanded>
+                <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
+                  <Typography variant="body2">Chat</Typography>
+                </ExpansionPanelSummary>
+                <ExpansionPanelDetails>
+                  <Chat
+                    start={getBattle.Started}
+                    end={
+                      Number(getBattle.Started) +
+                      Number(getBattle.Duration * 60)
+                    }
+                  />
+                </ExpansionPanelDetails>
+              </ExpansionPanel>
+            )}
           </div>
         </div>
         <div className={s.levelStatsContainer}>
@@ -168,19 +176,20 @@ class Battle extends React.Component {
                   </TableRow>
                 </TableHead>
                 <TableBody>
-                  {[...getBattle.Results]
-                    .sort(sortResults(getBattle.BattleType))
-                    .map((r, i) => (
-                      <TableRow key={r.KuskiIndex}>
-                        <TableCell>{i + 1}.</TableCell>
-                        <TableCell>
-                          <Kuski kuskiData={r.KuskiData} flag team />
-                        </TableCell>
-                        <TableCell>
-                          <Time time={r.Time} apples={r.Apples} />
-                        </TableCell>
-                      </TableRow>
-                    ))}
+                  {getBattle.Finished === 1 &&
+                    [...getBattle.Results]
+                      .sort(sortResults(getBattle.BattleType))
+                      .map((r, i) => (
+                        <TableRow key={r.KuskiIndex}>
+                          <TableCell>{i + 1}.</TableCell>
+                          <TableCell>
+                            <Kuski kuskiData={r.KuskiData} flag team />
+                          </TableCell>
+                          <TableCell>
+                            <Time time={r.Time} apples={r.Apples} />
+                          </TableCell>
+                        </TableRow>
+                      ))}
                 </TableBody>
               </Table>
             )}

--- a/src/routes/battle/Battle.js
+++ b/src/routes/battle/Battle.js
@@ -13,7 +13,7 @@ import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
 import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import Paper from '@material-ui/core/Paper';
-import { sortResults } from 'utils';
+import { sortResults, battleStatus } from 'utils';
 import s from './Battle.css';
 import battleQuery from './battle.graphql';
 import Recplayer from '../../components/Recplayer';
@@ -48,8 +48,7 @@ class Battle extends React.Component {
           <div className={s.playerContainer}>
             <div className={s.player}>
               {isWindow &&
-                (getBattle.InQueue === 0 ||
-                  (getBattle.Aborted === 1 && getBattle.InQueue === 1)) && (
+                !(battleStatus(getBattle) === 'Queued') && (
                   <Recplayer
                     rec={`/dl/battlereplay/${BattleIndex}`}
                     lev={`/dl/level/${getBattle.LevelIndex}`}
@@ -88,53 +87,56 @@ class Battle extends React.Component {
                 </div>
               </ExpansionPanelDetails>
             </ExpansionPanel>
-            {getBattle.BattleType === 'NM' && (
-              <ExpansionPanel defaultExpanded>
-                <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
-                  <Typography variant="body2">Leader history</Typography>
-                </ExpansionPanelSummary>
-                <ExpansionPanelDetails>
-                  <div className={s.timeDevelopment}>
-                    {[...getAllBattleTimes]
-                      .reduce((acc, cur) => {
-                        if (
-                          acc.length < 1 ||
-                          acc[acc.length - 1].Time > cur.Time
-                        )
-                          acc.push(cur);
-                        return acc;
-                      }, [])
-                      .map((b, i, a) => (
-                        <div className={s.timeDevelopmentRow} key={b.TimeIndex}>
-                          <span className={s.timeDiff}>
-                            {a.length > 1 && !a[i + 1] && 'Winner'}
-                            {a[i - 1] && (
-                              <span>
-                                {' '}
-                                -<Time time={a[i - 1].Time - b.Time} />
-                              </span>
-                            )}
-                            {a.length > 1 && !a[i - 1] && 'First finish'}
-                            {a.length === 1 && 'Only finish'}
-                          </span>
-                          <span className={s.timelineCell}>
-                            <span className={s.timelineMarker} />
-                            <span className={s.timelineLine} />
-                          </span>
-                          <span className={s.timeDevelopmentTime}>
-                            <Time time={b.Time} />
-                          </span>
-                          <span className={s.timeDevelopmentKuski}>
-                            {b.KuskiData.Kuski}
-                          </span>
-                        </div>
-                      ))}
-                  </div>
-                </ExpansionPanelDetails>
-              </ExpansionPanel>
-            )}
-            {(getBattle.InQueue === 0 ||
-              (getBattle.Aborted === 1 && getBattle.InQueue === 1)) && (
+            {getBattle.Finished === 1 &&
+              getBattle.BattleType === 'NM' && (
+                <ExpansionPanel defaultExpanded>
+                  <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
+                    <Typography variant="body2">Leader history</Typography>
+                  </ExpansionPanelSummary>
+                  <ExpansionPanelDetails>
+                    <div className={s.timeDevelopment}>
+                      {[...getAllBattleTimes]
+                        .reduce((acc, cur) => {
+                          if (
+                            acc.length < 1 ||
+                            acc[acc.length - 1].Time > cur.Time
+                          )
+                            acc.push(cur);
+                          return acc;
+                        }, [])
+                        .map((b, i, a) => (
+                          <div
+                            className={s.timeDevelopmentRow}
+                            key={b.TimeIndex}
+                          >
+                            <span className={s.timeDiff}>
+                              {a.length > 1 && !a[i + 1] && 'Winner'}
+                              {a[i - 1] && (
+                                <span>
+                                  {' '}
+                                  -<Time time={a[i - 1].Time - b.Time} />
+                                </span>
+                              )}
+                              {a.length > 1 && !a[i - 1] && 'First finish'}
+                              {a.length === 1 && 'Only finish'}
+                            </span>
+                            <span className={s.timelineCell}>
+                              <span className={s.timelineMarker} />
+                              <span className={s.timelineLine} />
+                            </span>
+                            <span className={s.timeDevelopmentTime}>
+                              <Time time={b.Time} />
+                            </span>
+                            <span className={s.timeDevelopmentKuski}>
+                              {b.KuskiData.Kuski}
+                            </span>
+                          </div>
+                        ))}
+                    </div>
+                  </ExpansionPanelDetails>
+                </ExpansionPanel>
+              )}
+            {!(battleStatus(getBattle) === 'Queued') && (
               <ExpansionPanel defaultExpanded>
                 <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
                   <Typography variant="body2">Chat</Typography>
@@ -176,7 +178,7 @@ class Battle extends React.Component {
                   </TableRow>
                 </TableHead>
                 <TableBody>
-                  {getBattle.Finished === 1 &&
+                  {battleStatus(getBattle) === 'Finished' &&
                     [...getBattle.Results]
                       .sort(sortResults(getBattle.BattleType))
                       .map((r, i) => (

--- a/src/routes/battle/battle.graphql
+++ b/src/routes/battle/battle.graphql
@@ -6,6 +6,9 @@ query Battletime($BattleIndex: Int!) {
     Duration
     RecFileName
     Started
+    Aborted
+    InQueue
+    Finished
     LevelData {
       LevelName
     }

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -11,7 +11,7 @@ import TableRow from '@material-ui/core/TableRow';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
 import Paper from '@material-ui/core/Paper';
-import { toLocalTime } from 'utils';
+import { toLocalTime, battleStatus, battleStatusBgColor } from 'utils';
 import homeQuery from './home.graphql'; // import the graphql query here
 import s from './Home.css';
 import { Kuski, Level, BattleType } from '../../components/Names';
@@ -75,9 +75,10 @@ class Home extends React.Component {
               <Table>
                 <TableHead>
                   <TableRow>
-                    <TableCell>Time</TableCell>
-                    <TableCell>Level</TableCell>
+                    <TableCell>Started</TableCell>
                     <TableCell>Designer</TableCell>
+                    <TableCell>Level</TableCell>
+                    <TableCell>Winner</TableCell>
                     <TableCell>Type</TableCell>
                     <TableCell>Duration</TableCell>
                   </TableRow>
@@ -87,17 +88,12 @@ class Home extends React.Component {
                   {loading
                     ? 'Loading...'
                     : battleList.map(i => (
+                        // const sorted = [...i.Results].sort(sortResults);
                         <TableRow
-                          style={
-                            i.InQueue === 0 &&
-                            i.Aborted === 0 &&
-                            i.Finished === 0
-                              ? {
-                                  cursor: 'pointer',
-                                  backgroundColor: '#2566a7',
-                                }
-                              : { cursor: 'pointer' }
-                          }
+                          style={{
+                            cursor: 'pointer',
+                            backgroundColor: battleStatusBgColor(i),
+                          }}
                           hover
                           key={i.BattleIndex}
                           onClick={() => {
@@ -105,41 +101,30 @@ class Home extends React.Component {
                           }}
                         >
                           <TableCell>
-                            {i.Aborted === 1 ? (
-                              <Link to={`/battles/${i.BattleIndex}`}>
-                                Aborted
-                              </Link>
-                            ) : (
-                              [
-                                i.InQueue === 1 ? (
-                                  <Link to={`/battles/${i.BattleIndex}`}>
-                                    Queued
-                                  </Link>
-                                ) : (
-                                  <Link to={`/battles/${i.BattleIndex}`}>
-                                    <LocalTime
-                                      date={i.Started}
-                                      format="HH:mm:ss"
-                                      parse="X"
-                                    />
-                                  </Link>
-                                ),
-                              ]
-                            )}
-                          </TableCell>
-                          <TableCell>
-                            <Level index={i.LevelIndex} />
+                            <Link to={`/battles/${i.BattleIndex}`}>
+                              <LocalTime
+                                date={i.Started}
+                                format="HH:mm:ss"
+                                parse="X"
+                              />
+                            </Link>
                           </TableCell>
                           <TableCell>
                             <Kuski index={i.KuskiIndex} />
                           </TableCell>
                           <TableCell>
+                            <Link to={`/dl/level/${i.LevelIndex}`}>
+                              <Level index={i.LevelIndex} />
+                            </Link>
+                          </TableCell>
+                          <TableCell>
+                            {i.Finished === 1 ? 'Winner' : battleStatus(i)}
+                          </TableCell>
+                          <TableCell>
                             <BattleType type={i.BattleType} />
                           </TableCell>
                           <TableCell>
-                            {i.InQueue === 0 &&
-                            i.Aborted === 0 &&
-                            i.Finished === 0
+                            {battleStatus(i) === 'Ongoing'
                               ? this.remaining(i.Started, i.Duration)
                               : i.Duration}
                           </TableCell>

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -11,10 +11,16 @@ import TableRow from '@material-ui/core/TableRow';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
 import Paper from '@material-ui/core/Paper';
-import { toLocalTime, battleStatus, battleStatusBgColor } from 'utils';
+import {
+  sortResults,
+  toLocalTime,
+  battleStatus,
+  battleStatusBgColor,
+} from 'utils';
 import homeQuery from './home.graphql'; // import the graphql query here
 import s from './Home.css';
-import { Kuski, Level, BattleType } from '../../components/Names';
+import { Level, BattleType } from '../../components/Names';
+import Kuski from '../../components/Kuski';
 import history from '../../history';
 import Upload from '../../components/Upload';
 import RecListItem from '../../components/RecListItem';
@@ -87,49 +93,59 @@ class Home extends React.Component {
                   {/* iterate the data object here, loading is an object created automatically which will be true while loading the data */}
                   {loading
                     ? 'Loading...'
-                    : battleList.map(i => (
-                        // const sorted = [...i.Results].sort(sortResults);
-                        <TableRow
-                          style={{
-                            cursor: 'pointer',
-                            backgroundColor: battleStatusBgColor(i),
-                          }}
-                          hover
-                          key={i.BattleIndex}
-                          onClick={() => {
-                            this.gotoBattle(i.BattleIndex);
-                          }}
-                        >
-                          <TableCell>
-                            <Link to={`/battles/${i.BattleIndex}`}>
-                              <LocalTime
-                                date={i.Started}
-                                format="HH:mm:ss"
-                                parse="X"
-                              />
-                            </Link>
-                          </TableCell>
-                          <TableCell>
-                            <Kuski index={i.KuskiIndex} />
-                          </TableCell>
-                          <TableCell>
-                            <Link to={`/dl/level/${i.LevelIndex}`}>
-                              <Level index={i.LevelIndex} />
-                            </Link>
-                          </TableCell>
-                          <TableCell>
-                            {i.Finished === 1 ? 'Winner' : battleStatus(i)}
-                          </TableCell>
-                          <TableCell>
-                            <BattleType type={i.BattleType} />
-                          </TableCell>
-                          <TableCell>
-                            {battleStatus(i) === 'Ongoing'
-                              ? this.remaining(i.Started, i.Duration)
-                              : i.Duration}
-                          </TableCell>
-                        </TableRow>
-                      ))}
+                    : battleList.map(i => {
+                        const sorted = [...i.Results].sort(sortResults);
+                        return (
+                          <TableRow
+                            style={{
+                              cursor: 'pointer',
+                              backgroundColor: battleStatusBgColor(i),
+                            }}
+                            hover
+                            key={i.BattleIndex}
+                            onClick={() => {
+                              this.gotoBattle(i.BattleIndex);
+                            }}
+                          >
+                            <TableCell>
+                              <Link to={`/battles/${i.BattleIndex}`}>
+                                <LocalTime
+                                  date={i.Started}
+                                  format="HH:mm:ss"
+                                  parse="X"
+                                />
+                              </Link>
+                            </TableCell>
+                            <TableCell>
+                              <Kuski kuskiData={i.KuskiData} team flag />
+                            </TableCell>
+                            <TableCell>
+                              <Link to={`/dl/level/${i.LevelIndex}`}>
+                                <Level index={i.LevelIndex} />
+                              </Link>
+                            </TableCell>
+                            <TableCell>
+                              {i.Finished === 1 ? (
+                                <Kuski
+                                  kuskiData={sorted[0].KuskiData}
+                                  team
+                                  flag
+                                />
+                              ) : (
+                                battleStatus(i)
+                              )}
+                            </TableCell>
+                            <TableCell>
+                              <BattleType type={i.BattleType} />
+                            </TableCell>
+                            <TableCell>
+                              {battleStatus(i) === 'Ongoing'
+                                ? this.remaining(i.Started, i.Duration)
+                                : i.Duration}
+                            </TableCell>
+                          </TableRow>
+                        );
+                      })}
                 </TableBody>
               </Table>
             </Paper>

--- a/src/routes/home/home.graphql
+++ b/src/routes/home/home.graphql
@@ -9,6 +9,33 @@ query HomeNews {
     InQueue
     Aborted
     Finished
+    KuskiData {
+      KuskiIndex
+      Kuski
+      Country
+      TeamData {
+        Team
+      }
+    }
+    LevelData {
+      LevelName
+    }
+    Results {
+      BattleTimeIndex
+      BattleIndex
+      KuskiIndex
+      KuskiIndex2
+      Time
+      Apples
+      TimeIndex
+      KuskiData {
+        Kuski
+        Country
+        TeamData {
+          Team
+        }
+      }
+    }
   }
   getReplays {
     ReplayIndex

--- a/src/routes/level/Level.css
+++ b/src/routes/level/Level.css
@@ -5,7 +5,7 @@
 }
 
 .playerContainer {
-  width: 70%;
+  width: 60%;
   float: left;
   padding: 7px;
   box-sizing: border-box;
@@ -21,13 +21,13 @@
 
 .rightBarContainer {
   float: right;
-  width: 30%;
+  width: 40%;
   padding: 7px;
   box-sizing: border-box;
 }
 
 .resultsContainer {
-  width: 70%;
+  width: 60%;
   float: left;
   padding: 7px;
   box-sizing: border-box;

--- a/src/routes/level/Level.js
+++ b/src/routes/level/Level.js
@@ -14,12 +14,12 @@ import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import Paper from '@material-ui/core/Paper';
 import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
-import { battleStatus, battleStatusBgColor } from 'utils';
+import { sortResults, battleStatus, battleStatusBgColor } from 'utils';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
 import query from './level.graphql';
 import allTimesQuery from './allTimes.graphql';
 import s from './Level.css';
-import { Kuski } from '../../components/Names';
+import Kuski from '../../components/Kuski';
 import history from '../../history';
 import Recplayer from '../../components/Recplayer';
 import RecList from '../../components/RecList';
@@ -154,7 +154,7 @@ class Level extends React.Component {
               </ExpansionPanelSummary>
               <ExpansionPanelDetails>
                 <div>
-                  <Table style={{ overflowX: 'auto' }}>
+                  <Table>
                     <TableHead>
                       <TableRow>
                         <TableCell>Started</TableCell>
@@ -166,37 +166,47 @@ class Level extends React.Component {
                     <TableBody>
                       {loading
                         ? 'Loading...'
-                        : getBattlesForLevel.map(i => (
-                            // const sorted = [...i.Results].sort(sortResults);
-                            <TableRow
-                              style={{
-                                cursor: 'pointer',
-                                backgroundColor: battleStatusBgColor(i),
-                              }}
-                              hover
-                              key={i.BattleIndex}
-                              onClick={() => {
-                                this.gotoBattle(i.BattleIndex);
-                              }}
-                            >
-                              <TableCell>
-                                <Link to={`/battles/${i.BattleIndex}`}>
-                                  <LocalTime
-                                    date={i.Started}
-                                    format="DD MMM YYYY HH:mm:ss"
-                                    parse="X"
-                                  />
-                                </Link>
-                              </TableCell>
-                              <TableCell>
-                                <Kuski index={i.KuskiIndex} />
-                              </TableCell>
-                              <TableCell>
-                                {i.Finished === 1 ? 'Winner' : battleStatus(i)}
-                              </TableCell>
-                              <TableCell>{i.BattleIndex}</TableCell>
-                            </TableRow>
-                          ))}
+                        : getBattlesForLevel.map(i => {
+                            const sorted = [...i.Results].sort(sortResults);
+                            return (
+                              <TableRow
+                                style={{
+                                  cursor: 'pointer',
+                                  backgroundColor: battleStatusBgColor(i),
+                                }}
+                                hover
+                                key={i.BattleIndex}
+                                onClick={() => {
+                                  this.gotoBattle(i.BattleIndex);
+                                }}
+                              >
+                                <TableCell>
+                                  <Link to={`/battles/${i.BattleIndex}`}>
+                                    <LocalTime
+                                      date={i.Started}
+                                      format="DD MMM YYYY HH:mm:ss"
+                                      parse="X"
+                                    />
+                                  </Link>
+                                </TableCell>
+                                <TableCell>
+                                  <Kuski kuskiData={i.KuskiData} team flag />
+                                </TableCell>
+                                <TableCell>
+                                  {i.Finished === 1 ? (
+                                    <Kuski
+                                      kuskiData={sorted[0].KuskiData}
+                                      team
+                                      flag
+                                    />
+                                  ) : (
+                                    battleStatus(i)
+                                  )}
+                                </TableCell>
+                                <TableCell>{i.BattleIndex}</TableCell>
+                              </TableRow>
+                            );
+                          })}
                     </TableBody>
                   </Table>
                 </div>

--- a/src/routes/level/level.graphql
+++ b/src/routes/level/level.graphql
@@ -20,12 +20,36 @@ query Level($LevelIndex: Int!) {
     LevelIndex
     BattleType
     Started
-    StartedUtc
     Duration
+    InQueue
     Aborted
     Finished
-    InQueue
-    Countdown
-    RecFileName
+    KuskiData {
+      KuskiIndex
+      Kuski
+      Country
+      TeamData {
+        Team
+      }
+    }
+    LevelData {
+      LevelName
+    }
+    Results {
+      BattleTimeIndex
+      BattleIndex
+      KuskiIndex
+      KuskiIndex2
+      Time
+      Apples
+      TimeIndex
+      KuskiData {
+        Kuski
+        Country
+        TeamData {
+          Team
+        }
+      }
+    }
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -39,6 +39,9 @@ const battleStatus = data => {
   if (data.Aborted === 0 && data.InQueue === 0 && data.Finished === 0) {
     status = 'Ongoing';
   }
+  if (data.Finished === 1) {
+    status = 'Finished';
+  }
   return status;
 };
 const battleStatusBgColor = data => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -28,5 +28,37 @@ const sortResults = battleType => (a, b) => {
   const d = b.Apples - a.Apples;
   return d === 0 ? a.BattleTimeIndex - b.BattleTimeIndex : d;
 };
+const battleStatus = data => {
+  let status;
+  if (data.Aborted === 1) {
+    status = 'Aborted';
+  }
+  if (data.Aborted === 0 && data.InQueue === 1) {
+    status = 'Queued';
+  }
+  if (data.Aborted === 0 && data.InQueue === 0 && data.Finished === 0) {
+    status = 'Ongoing';
+  }
+  return status;
+};
+const battleStatusBgColor = data => {
+  let bgColor;
+  if (data.Aborted === 1) {
+    bgColor = '#ffb3ba';
+  }
+  if (data.Aborted === 0 && data.InQueue === 1) {
+    bgColor = '#baffc9';
+  }
+  if (data.Aborted === 0 && data.InQueue === 0 && data.Finished === 0) {
+    bgColor = '#bae1ff';
+  }
+  return bgColor;
+};
 
-export { toServerTime, toLocalTime, sortResults };
+export {
+  toServerTime,
+  toLocalTime,
+  sortResults,
+  battleStatus,
+  battleStatusBgColor,
+};


### PR DESCRIPTION
Battle and level pages are now visible, but with limited content, as per #88. Highlighting of the three types of battles was refactored to be neater and more flexible; background colour is defined in a utils.js function now.

Outstanding issue: some sensitive battle data is being leaked with overly broad db queries. Some were added/expanded by me, but I think some were also leaky before. I'll go through the queries tomorrow and try to refactor them so that only safe data is pulled.
**Please do not push to elma.online before the above is confirmed.**
It would be useful to test it on test.elma.online though, together with other fixes.

------------------------------------------------------------------------------
**Update:**
fixed/updated display of Kuskis in battle tables on the home page and on level pages (display with flags and teams now).

Query filtering is in progress.

------------------------------------------------------------------------------
**Update:**
See conversation below. Should be safe to deploy.