### PR TITLE
feat(levelpack): display best time in level pack level listing

### DIFF
--- a/src/data/graphql/Database/time/GetTimes.js
+++ b/src/data/graphql/Database/time/GetTimes.js
@@ -48,7 +48,7 @@ export const schema = [
 export const queries = [
   `
     getTimes(LevelIndex: Int!): [DatabaseTime]
-    getBestTimes(LevelIndex: Int!): [DatabaseBestTime]
+    getBestTimes(LevelIndex: Int!, Limit: Int): [DatabaseBestTime]
   `,
 ];
 
@@ -77,7 +77,7 @@ export const resolvers = {
       });
       return times;
     }, */
-    async getBestTimes(parent, { LevelIndex }) {
+    async getBestTimes(parent, { LevelIndex, Limit }) {
       const level = await Level.findOne({
         attributes: ['Hidden', 'Locked'],
         where: { LevelIndex },
@@ -90,6 +90,7 @@ export const resolvers = {
       const times = await sourceModel.findAll({
         where: { LevelIndex },
         order: [['Time', 'ASC']],
+        limit: Limit,
         include: [
           {
             model: Kuski,

--- a/src/pages/levelpack/LevelPack.css
+++ b/src/pages/levelpack/LevelPack.css
@@ -50,6 +50,14 @@
   width: 70px;
 }
 
+.levels > * > span:nth-child(2) {
+  width: 300px;
+}
+
+.levels > * > span:nth-child(3) {
+  width: 180px;
+}
+
 .levels a:hover {
   background: #f9f9f9;
 }

--- a/src/pages/levelpack/LevelPack.js
+++ b/src/pages/levelpack/LevelPack.js
@@ -33,7 +33,7 @@ const GET_LEVELPACK = gql`
 
 const GET_LEVEL = gql`
   query($LevelIndex: Int!) {
-    getBestTimes(LevelIndex: $LevelIndex) {
+    getBestTimes(LevelIndex: $LevelIndex, Limit: 10) {
       TimeIndex
       KuskiIndex
       Time
@@ -48,6 +48,23 @@ const GET_LEVEL = gql`
     getLevel(LevelIndex: $LevelIndex) {
       LevelName
       LongName
+    }
+  }
+`;
+
+const GET_BEST_TIME = gql`
+  query($LevelIndex: Int!) {
+    getBestTimes(LevelIndex: $LevelIndex, Limit: 1) {
+      TimeIndex
+      KuskiIndex
+      Time
+      KuskiData {
+        Kuski
+        Country
+        TeamData {
+          Team
+        }
+      }
     }
   }
 `;
@@ -83,7 +100,7 @@ const LevelPopup = withStyles(s)(({ levelId, close }) => {
                     <span>Kuski</span>
                     <span>Time</span>
                   </div>
-                  {getBestTimes.splice(0, 10).map((t, i) => {
+                  {getBestTimes.map((t, i) => {
                     return (
                       <div key={t.TimeIndex}>
                         <span>{i + 1}.</span>
@@ -133,6 +150,8 @@ const LevelPack = ({ name }) => {
                 <div className={s.tableHead}>
                   <span>Filename</span>
                   <span>Level name</span>
+                  <span>Kuski</span>
+                  <span>Time</span>
                 </div>
                 {getLevelPack.Levels.map(l => {
                   return (
@@ -147,6 +166,33 @@ const LevelPack = ({ name }) => {
                     >
                       <span>{l.Level.LevelName}</span>
                       <span>{l.Level.LongName}</span>
+                      <Query
+                        query={GET_BEST_TIME}
+                        variables={{ LevelIndex: l.LevelIndex }}
+                      >
+                        {({ data: { getBestTimes } }) => {
+                          if (!getBestTimes || getBestTimes.length < 1)
+                            return (
+                              <>
+                                <span />
+                                <span />
+                              </>
+                            );
+
+                          return getBestTimes.map(t => {
+                            return (
+                              <React.Fragment key={t.TimeIndex}>
+                                <span>
+                                  <Kuski kuskiData={t.KuskiData} team flag />
+                                </span>
+                                <span>
+                                  <Time time={t.Time} />
+                                </span>
+                              </React.Fragment>
+                            );
+                          });
+                        }}
+                      </Query>
                     </Link>
                   );
                 })}


### PR DESCRIPTION
Display the best time in level pack level listing.

Additionally this PR fixes the bug when selecting the same level on the levpack level list several times it would show less and less of top10 times each time. Also introduces possibility to define how many best times are queried from the db for the selected level.