### PR TITLE
refactor: 💡 Store bn store and logs outside builds reach

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,5 @@ events/*
 public/replays/
 
 # Battle Notifier
+bn/
 *.store.json

--- a/src/config.js
+++ b/src/config.js
@@ -94,6 +94,7 @@ module.exports = {
       ended: '',
     },
     prefix: '!',
-    bnStorePath: 'bn.store.json',
+    bnStorePath: '../bn/bn.store.json',
+    bnLogsPath: '../bn/logs/',
   },
 };

--- a/src/utils/discord/battleNotifier/bnStore/bnStore.js
+++ b/src/utils/discord/battleNotifier/bnStore/bnStore.js
@@ -1,6 +1,9 @@
 const { writeJsonFile, readJsonFile } = require('./jsonFs');
+const { createParentFolder } = require('../../fileUtils');
 
 const createBnStore = path => {
+  createParentFolder(path);
+
   const getAll = async () => {
     return readJsonFile(path);
   };

--- a/src/utils/discord/battleNotifier/bnStore/jsonFs.js
+++ b/src/utils/discord/battleNotifier/bnStore/jsonFs.js
@@ -1,13 +1,9 @@
-const fs = require('fs');
-const util = require('util');
-
-fs.readFileAsync = util.promisify(fs.readFile);
-fs.writeFileAsync = util.promisify(fs.writeFile);
+const { readFile, writeFile } = require('../../fileUtils');
 
 const readJsonFile = async path => {
   let result = {};
   try {
-    const fileHandle = await fs.readFileAsync(path);
+    const fileHandle = await readFile(path);
     result = JSON.parse(fileHandle.toString());
   } catch (error) {
     result = {};
@@ -16,8 +12,8 @@ const readJsonFile = async path => {
   return result;
 };
 
-const writeJsonFile = async (fileName, data) => {
-  await fs.writeFileAsync(fileName, JSON.stringify(data));
+const writeJsonFile = async (path, data) => {
+  await writeFile(path, JSON.stringify(data));
 };
 
 module.exports = {

--- a/src/utils/discord/discord.js
+++ b/src/utils/discord/discord.js
@@ -6,10 +6,15 @@ const createBN = require('./battleNotifier');
 const logger = require('./logger');
 
 const client = new Discord.Client();
-const battleNotifier = createBN({
-  bnStorePath: config.discord.bnStorePath,
-  client,
-});
+
+const isProdEnv = process.env.NODE_ENV === 'production';
+const bnStorePath = isProdEnv
+  ? config.discord.bnStorePath
+  : './bn/bn.store.json';
+const battleNotifier = createBN({ bnStorePath, client });
+
+const bnLogsPath = isProdEnv ? config.discord.bnLogsPath : './bn/';
+logger.initialize(bnLogsPath);
 
 function discord() {
   client.once('ready', () => {

--- a/src/utils/discord/fileUtils.js
+++ b/src/utils/discord/fileUtils.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+const util = require('util');
+const { dirname } = require('path');
+
+const readFile = util.promisify(fs.readFile);
+const writeFile = util.promisify(fs.writeFile);
+const mkdirAsync = util.promisify(fs.mkdir);
+
+const createFolder = async path => {
+  await mkdirAsync(path, { recursive: true });
+};
+
+const createParentFolder = async path => {
+  const folderPath = dirname(path);
+  await createFolder(folderPath);
+};
+
+module.exports = { readFile, writeFile, createFolder, createParentFolder };

--- a/src/utils/discord/logger.js
+++ b/src/utils/discord/logger.js
@@ -1,20 +1,37 @@
 const fs = require('fs');
 const { format } = require('date-fns');
+const { createFolder } = require('./fileUtils.js');
 
-const logsFolder = './bn';
-const getFilePath = dateString => `${logsFolder}/${dateString}.log`;
+let logger = null;
+logger =
+  logger ||
+  (() => {
+    let path = '';
+    const initialize = async logsPath => {
+      path = logsPath;
+      await createFolder(path);
+    };
 
-const log = ({ userName, userId, action, message, stack }) => {
-  const dateNow = new Date();
-  const date = format(dateNow, 'yyyy-MM-dd');
-  const time = format(dateNow, 'HH:mm:ss');
-  const stackMessage = stack ? `STACK: ${stack}` : '';
+    const getFilePath = dateString => `${path}${dateString}.log`;
 
-  fs.appendFile(
-    getFilePath(date),
-    `[${time}] ${action} - ${userName} (${userId}): ${message} ${stackMessage}\r\n`,
-    () => {},
-  );
-};
+    const log = ({ userName, userId, action, message, stack }) => {
+      const dateNow = new Date();
+      const date = format(dateNow, 'yyyy-MM-dd');
+      const time = format(dateNow, 'HH:mm:ss');
+      const stackMessage = stack ? `STACK: ${stack}` : '';
 
-module.exports = { log, getFilePath };
+      try {
+        fs.appendFile(
+          getFilePath(date),
+          `[${time}] ${action} - ${userName} (${userId}): ${message} ${stackMessage}\r\n`,
+          () => {},
+        );
+      } catch {
+        // Log failed
+      }
+    };
+
+    return { initialize, log, getFilePath };
+  })();
+
+module.exports = logger;


### PR DESCRIPTION
Updated the discord Logger so it now retains a path defined at the config file instead of a hardcoded string internally.

`bnStore.js` already received it's file path at initialization.

For the logger and bnStore added a new line at initialization that creates the storage folder if it doesn't already exists, using the initialization path.

Both paths are defined at the config file like:
```json
bnStorePath: '../bn/bn.store.json',
bnLogsPath: '../bn/logs/',
```

If it's not a production environment it will just use a `./bn/` folder for both store and logs, that will be ignored by `.gitignore`.
