### PR TITLE
style: 💄 Fix cup event link color on highlighted event

### DIFF
--- a/src/pages/cup/Events.js
+++ b/src/pages/cup/Events.js
@@ -53,12 +53,9 @@ const Cups = props => {
             <EventNo>{i + 1}.</EventNo>
             <RightSide>
               <By>
-                <EventLink
-                  highlight={i === openEvent}
-                  href={`/dl/level/${e.LevelIndex}`}
-                >
+                <a href={`/dl/level/${e.LevelIndex}`}>
                   {e.Level ? e.Level.LevelName : ''}
-                </EventLink>{' '}
+                </a>{' '}
                 by <Kuski kuskiData={e.KuskiData} />
               </By>
               <div>
@@ -151,10 +148,6 @@ const Cups = props => {
   );
 };
 
-const EventLink = styled.a`
-  color: ${p => (p.highlight ? 'white' : '#219653')};
-`;
-
 const PlayerContainer = styled.div`
   display: flex;
   align-items: center;
@@ -173,6 +166,9 @@ const EventContainer = styled.div`
   cursor: pointer;
   background-color: ${props => (props.highlight ? '#219653' : 'transparent')};
   color: ${props => (props.highlight ? 'white' : 'black')};
+  a {
+    color: ${props => (props.highlight ? 'white' : '#219653')};
+  }
 `;
 
 const EventNo = styled.div`


### PR DESCRIPTION
Lifted up the condition for coloring links from `EventLink` to `EventContainer` so it also takes effect for `Kuski` inner links.

When the `Event` is highlighted the background color turns green but the `Kuski` inner link kept green instead of turning white, so it vanished :D

### Reproduce

1. Go to a Cup.
2. Go to the Events tab.
3. Select an Event.
4. The Kuski name vanished in the green background => now turns white