### PR TITLE
fix(cups): fix other replays table sync issue

### DIFF
--- a/src/components/Table/DerpTable.js
+++ b/src/components/Table/DerpTable.js
@@ -12,7 +12,16 @@ import PaginationActions from 'components/Table/PaginationActions';
 
 class DerpTable extends React.Component {
   static propTypes = {
-    headers: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
+    headers: PropTypes.arrayOf(
+      PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.shape({
+          t: PropTypes.string,
+          r: PropTypes.bool,
+          w: PropTypes.string,
+        }),
+      ]),
+    ).isRequired,
     loading: PropTypes.bool,
     children: PropTypes.node.isRequired,
     length: PropTypes.number,
@@ -56,14 +65,14 @@ class DerpTable extends React.Component {
         <ListContainer>
           <ListHeader>
             {headers.map(h => (
-              <>
+              <React.Fragment key={h.t || h}>
                 {typeof h === 'string' && <ListCell key={h}>{h}</ListCell>}
                 {typeof h === 'object' && (
                   <ListCell key={h} right={h.r} width={h.w}>
                     {h.t}
                   </ListCell>
                 )}
-              </>
+              </React.Fragment>
             ))}
           </ListHeader>
           {loading && <CircularProgress />}

--- a/src/pages/cup/Events.js
+++ b/src/pages/cup/Events.js
@@ -43,6 +43,7 @@ const Cups = props => {
       <Grid item xs={12} sm={6}>
         {events.sort(eventSort).map((e, i) => (
           <EventContainer
+            key={e.CupIndex}
             highlight={i === openEvent}
             onClick={() => setOpenEvent(i)}
           >

--- a/src/pages/cupreplay/CupReplay.js
+++ b/src/pages/cupreplay/CupReplay.js
@@ -54,7 +54,7 @@ const CupReplays = ({ ReplayIndex, Filename }) => {
         });
       }
     }
-  }, [replayLoaded, ReplayIndex]);
+  }, [replay, replayLoaded, ReplayIndex]);
 
   if (!replayLoaded) return <Loading />;
   if (!replay.CupData) return <div>Unable to load replay</div>;
@@ -120,6 +120,7 @@ const CupReplays = ({ ReplayIndex, Filename }) => {
                 <>
                   {others.map(t => (
                     <ListRow
+                      key={t.CupTimeIndex}
                       selected={t.CupTimeIndex === replay.CupTimeIndex}
                       onClick={() =>
                         goToReplay(


### PR DESCRIPTION
Fixed cup replay table sync issue. When watching a replay from an event and then visiting another replay from another event, the table below the replay used the replays from the previous visited event instead of the current one.

To fix this, added the `replay` to the `useEffect` dependency array. The `replay` changed but the `useEffect` didn't take it into account, because it was not listed as a dependency.

Other fixes: removed some warning from list of components without keys and DerpTable prop types. [Should always give unique keys when rendering an array of components](https://reactjs.org/docs/lists-and-keys.html#keys) and the DerpTable received an array of string or objects as `headers`.


### Reproduce on prod

1. Go to a cup (e.g. https://elma.online/cup/TTC1)
2. Go to Events tab
3. Select an Event (e.g. TTC101), results display
4. Select a replay (e.g. first result https://elma.online/r/cup/32209/TTC101Bjenn)
5. Go back on browser (arrow back, e.g. goes back to https://elma.online/cup/TTC1)
6. Go to Events tab
7. Select another Event (e.g TTC102), results display
8. Select a replay (e.g. first result https://elma.online/r/cup/32308/TTC102adi)
The results displayed below the replay are not correct, e.g. first result below should be "TTC102adi | adi | 18.62" but is "TTC102Bjenn | Bjenn | 14.10"
14.10 is the time on TTC101Bjenn on the previous event on this example TTC101.
9. Click on results to watch another player and redirects to replays on the first event.