### PR TITLE
fix(other): Fix notify BN old configs without new rules

### DIFF
--- a/src/utils/discord/battleNotifier/__tests__/notifyBattle.test.js
+++ b/src/utils/discord/battleNotifier/__tests__/notifyBattle.test.js
@@ -564,4 +564,25 @@ describe('with result cases', () => {
       expect(actual).toEqual(expected);
     });
   });
+
+  describe('test legacy configs', () => {
+    test('only battleTypes and designers defined works correctly', async () => {
+      const legacyConfig = {
+        createdAt: '2020-09-15T17:37:11.563Z',
+        updatedAt: '2020-09-15T19:37:39.237Z',
+        isOn: true,
+        notifyList: [{ battleTypes: ['Normal'], designers: [] }],
+        ignoreList: [],
+        username: 'ILKKA',
+      };
+      const store = mockStore({ '1': legacyConfig });
+      const battle = mockBattle({
+        battleType: 'Normal',
+        designer: 'Zero',
+      });
+      const actual = await getSubscribedUserIds({ battle, store });
+      const expected = ['1'];
+      expect(actual).toEqual(expected);
+    });
+  });
 });

--- a/src/utils/discord/battleNotifier/notifyBattle.js
+++ b/src/utils/discord/battleNotifier/notifyBattle.js
@@ -1,3 +1,5 @@
+const { UserConfig } = require('./userConfig');
+
 const onlyWordsRegExp = /^\w+$/;
 
 const matchesValue = (array, value) => {
@@ -76,9 +78,10 @@ const battleMatchesUserConfig = (battle, userConfig) =>
 
 const getSubscribedUserIds = async ({ battle, store }) => {
   const userConfigsById = await store.getAll();
-  const userConfigs = Object.entries(userConfigsById);
+  const storedConfigs = Object.entries(userConfigsById);
 
-  const userIds = userConfigs.reduce((acc, [userId, userConfig]) => {
+  const userIds = storedConfigs.reduce((acc, [userId, storedConfig]) => {
+    const userConfig = UserConfig(storedConfig);
     const isSubscribed =
       userConfig.isOn && battleMatchesUserConfig(battle, userConfig);
     return isSubscribed ? [...acc, userId] : acc;

--- a/src/utils/discord/battleNotifier/userConfig/UserConfig.js
+++ b/src/utils/discord/battleNotifier/userConfig/UserConfig.js
@@ -28,7 +28,7 @@ const UserConfigLists = values => {
 const UserConfig = values => {
   const createdAt = values.createdAt || '';
   const updatedAt = values.updatedAt || '';
-  const isOn = values.isOn || true;
+  const isOn = values.isOn !== undefined ? values.isOn : true;
   const lists = UserConfigLists({
     notifyList: values.notifyList,
     ignoreList: values.ignoreList,

--- a/src/utils/discord/discord.js
+++ b/src/utils/discord/discord.js
@@ -178,7 +178,15 @@ async function discordBattlestart(content) {
   const battleString = battleToString(content);
   sendMessage(config.discord.channels.battle, battleString);
 
-  battleNotifier.notifyBattle(content, battleString);
+  try {
+    await battleNotifier.notifyBattle(content, battleString);
+  } catch (error) {
+    logger.log({
+      action: 'discord-notify-battle',
+      message: error.message || error,
+      stack: error.stack,
+    });
+  }
 }
 
 function discordBattlequeue(content) {


### PR DESCRIPTION
Old legacy configs stored in `bnStore.json` didn't include some of the new rules like `levelPatterns` and notification code expects all configs to have all rules. 

I forgot to parse the configs coming from `store.getAll()` so that all configs are a consistent `UserConfig`.

Also added a missing top level try and catch for `battleNotifier.notifyBattle` at `discord.js`, since all async/await calls must be wrapped in try/catch at least at some top level.

Plus fixed a minor default value for `userConfig.isOn`:
```js
- const isOn = values.isOn || true; // always defaults to true.
+ const isOn = values.isOn !== undefined ? values.isOn : true;
```