### PR TITLE
fix(other): Fix BN regexp level patterns limited to 8 chars

### DIFF
--- a/src/utils/discord/battleNotifier/notifyBattle.js
+++ b/src/utils/discord/battleNotifier/notifyBattle.js
@@ -1,6 +1,4 @@
-const { UserConfig } = require('./userConfig');
-
-const onlyWordsRegExp = /^\w+$/;
+const { UserConfig, isSimpleLevelPattern } = require('./userConfig');
 
 const matchesValue = (array, value) => {
   const matchValue = value && value.toLowerCase();
@@ -8,8 +6,6 @@ const matchesValue = (array, value) => {
     array.length === 0 || array.some(item => item.toLowerCase() === matchValue)
   );
 };
-
-const isSimpleLevelPattern = string => onlyWordsRegExp.test(string);
 
 const matchesLevelPatterns = (levelPatterns, level) => {
   if (levelPatterns.length === 0) return true;

--- a/src/utils/discord/battleNotifier/userConfig/__tests__/userConfigParser.test.js
+++ b/src/utils/discord/battleNotifier/userConfig/__tests__/userConfigParser.test.js
@@ -219,7 +219,7 @@ describe('test good inputs', () => {
     });
 
     test('level pattern with over 8 characters is ignored', () => {
-      const userInput = '*9chars??.lev by Markku';
+      const userInput = 'has9chars.lev by Markku';
       const actual = userConfigParser.parse(userInput);
       const expected = UserConfigLists({
         notifyList: [{ designers: ['Markku'] }],
@@ -229,7 +229,7 @@ describe('test good inputs', () => {
 
     test('mutiple level names, parses valid level names correctly', () => {
       const userInput =
-        'Pob*.lev *1.lev ??*.lev *9chars??.lev incorrect.lev by Markku';
+        'Pob*.lev *1.lev ??*.lev has9chars.lev incorrect.lev by Markku';
       const actual = userConfigParser.parse(userInput);
       const expected = UserConfigLists({
         notifyList: [
@@ -244,7 +244,7 @@ describe('test good inputs', () => {
 
     test('mutiple level names, types and designers, parses valid level names correctly', () => {
       const userInput =
-        'Normal Pob*.lev First *1.lev Finish ??*.lev Apple *9chars??.lev by Markku1 Markku2 Markku3';
+        'Normal Pob*.lev First *1.lev Finish ??*.lev Apple has9chars.lev by Markku1 Markku2 Markku3';
       const actual = userConfigParser.parse(userInput);
       const expected = UserConfigLists({
         notifyList: [
@@ -252,6 +252,20 @@ describe('test good inputs', () => {
             battleTypes: ['Normal', 'First Finish', 'Apple'],
             designers: ['Markku1', 'Markku2', 'Markku3'],
             levelPatterns: ['Pob*', '*1', '??*'],
+          },
+        ],
+      });
+      expect(actual).toEqual(expected);
+    });
+
+    test('long regexp level name pattern is parse correctly', () => {
+      const userInput = '[a-zA-Z]+0+1$.lev by Markku';
+      const actual = userConfigParser.parse(userInput);
+      const expected = UserConfigLists({
+        notifyList: [
+          {
+            designers: ['Markku'],
+            levelPatterns: ['[a-zA-Z]+0+1$'],
           },
         ],
       });

--- a/src/utils/discord/battleNotifier/userConfig/index.js
+++ b/src/utils/discord/battleNotifier/userConfig/index.js
@@ -8,6 +8,7 @@ module.exports = {
   formatter: userConfigFormatter,
   getBattleVariations,
   areUserConfigListsEmpty: userConfigFormatter.areUserConfigListsEmpty,
+  isSimpleLevelPattern: userConfigParser.isSimpleLevelPattern,
   UserConfig,
   UserConfigLists,
 };

--- a/src/utils/discord/battleNotifier/userConfig/userConfigParser.js
+++ b/src/utils/discord/battleNotifier/userConfig/userConfigParser.js
@@ -5,6 +5,9 @@ const moreThanOneSpaceRegexp = /\s\s+/g;
 const commasRegexp = /,/g;
 const getLevelPatternsRegexp = suffix => new RegExp(`^.*${suffix}$`, 'gi');
 
+const onlyWordsRegExp = /^\w+$/;
+const isSimpleLevelPattern = string => onlyWordsRegExp.test(string);
+
 const substringInBetween = (input, startChar, endChar) => {
   const startIndex = input.indexOf(startChar) + 1;
   const endIndex = input.indexOf(endChar, startChar);
@@ -21,7 +24,8 @@ const getPrefixedNumber = (input, prefix) => {
 };
 
 const isValidLevelPattern = input =>
-  Boolean(input) && input.length > 0 && input.length <= 8;
+  Boolean(input) &&
+  (!isSimpleLevelPattern(input) || (input.length > 0 && input.length <= 8));
 
 const userConfigParser = ({ bnBattleTypes, bnBattleAttributes, keywords }) => {
   const parseDesignersInput = input => {
@@ -148,3 +152,4 @@ const userConfigParser = ({ bnBattleTypes, bnBattleAttributes, keywords }) => {
 };
 
 module.exports = userConfigParser;
+module.exports.isSimpleLevelPattern = isSimpleLevelPattern;


### PR DESCRIPTION
Complex level name patterns were limited to 8 characters as if they were simple patterns. This is because did not differentiate between simple and complex level name patterns during the parsing of the user input.

- Simplex patterns (only letters, numbers and underscore) can only be between 0 and 8 chars since level names have that limit.
- Complex patterns (regular expressions) can be of any length.
