### PR TITLE
fix(battles): leader time info when ff time is fastest

### DIFF
--- a/src/components/LeaderHistory/LeaderHistory.js
+++ b/src/components/LeaderHistory/LeaderHistory.js
@@ -101,7 +101,8 @@ export default function LeaderHistory({ allFinished }) {
                 </span>
               )}
               {a.length > 1 && !a[i - 1] && 'First finish'}
-              {a.length === 1 && 'Only finish'}
+              {a.length === 1 && allFinished.length !== 1 && 'First finish'}
+              {a.length === 1 && allFinished.length === 1 && 'Only finish'}
             </TimeDiff>
             <TimelineCell>
               <TimelineMarker />


### PR DESCRIPTION
Fix for the description of the leader time development line when 1) the first finished run is the fastest or 2) when there's only one finished run.