### PR TITLE
feat(replays): add tags for replays

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -19,6 +19,7 @@ import Mod from './mod';
 import News from './news';
 import Donate from './donate';
 import Upload from './upload';
+import Tag from './tag';
 
 const router = express.Router();
 
@@ -45,6 +46,7 @@ router
   .use('/news', News)
   .use('/teams', Teams)
   .use('/donate', Donate)
-  .use('/upload', Upload);
+  .use('/upload', Upload)
+  .use('/tag', Tag);
 
 export default router;

--- a/src/api/tag.js
+++ b/src/api/tag.js
@@ -1,0 +1,71 @@
+import { UniqueConstraintError, ForeignKeyConstraintError } from 'sequelize';
+import express from 'express';
+import { Tag } from '../data/models';
+import requireMod from '../middlewares/requireMod';
+
+const router = express.Router();
+
+const getTags = async () => {
+  const data = await Tag.findAll();
+  return data;
+};
+
+const createTag = async data => {
+  const created = await Tag.create(data);
+  return created;
+};
+
+const updateTag = async (id, data) => {
+  const updated = await Tag.update(data, { where: { TagIndex: id } });
+  return updated;
+};
+
+const deleteTag = async id => {
+  const deleted = await Tag.destroy({ where: { TagIndex: id } });
+  return deleted;
+};
+
+router
+  .get('/', async (req, res) => {
+    const data = await getTags();
+    res.json(data);
+  })
+  .post('/', requireMod, async (req, res) => {
+    try {
+      const data = await createTag(req.body);
+      res.json(data);
+    } catch (error) {
+      if (error instanceof UniqueConstraintError) {
+        res.status(400).json({ error: 'Tag with given name already exists.' });
+      } else {
+        res.sendStatus(400);
+      }
+    }
+  })
+  .put('/:id', requireMod, async (req, res) => {
+    try {
+      const data = await updateTag(req.params.id, req.body);
+      res.json(data);
+    } catch (error) {
+      if (error instanceof UniqueConstraintError) {
+        res.status(400).json({ error: 'Tag with given name already exists.' });
+      } else {
+        res.sendStatus(400);
+      }
+    }
+  })
+  .delete('/:id', requireMod, async (req, res) => {
+    try {
+      const data = await deleteTag(req.params.id);
+      res.json(data);
+    } catch (error) {
+      if (error instanceof ForeignKeyConstraintError) {
+        res.status(400).json({
+          error: "Can't delete tag because some replays are using it.",
+        });
+      }
+      res.sendStatus(400);
+    }
+  });
+
+export default router;

--- a/src/data/models/ReplayTags.js
+++ b/src/data/models/ReplayTags.js
@@ -1,0 +1,17 @@
+import DataType from 'sequelize';
+import Model from '../sequelize';
+
+const ReplayTags = Model.define('replay_tags', {
+  TagIndex: {
+    type: DataType.INTEGER,
+    allowNull: false,
+    defaultValue: false,
+  },
+  ReplayIndex: {
+    type: DataType.INTEGER,
+    allowNull: false,
+    defaultValue: false,
+  },
+});
+
+export default ReplayTags;

--- a/src/data/models/Tag.js
+++ b/src/data/models/Tag.js
@@ -1,0 +1,22 @@
+import DataType from 'sequelize';
+import Model from '../sequelize';
+
+const Tag = Model.define('tag', {
+  TagIndex: {
+    type: DataType.INTEGER,
+    autoIncrement: true,
+    allowNull: false,
+    primaryKey: true,
+  },
+  Name: {
+    type: DataType.STRING(255),
+    allowNull: false,
+  },
+  Hidden: {
+    type: DataType.INTEGER,
+    allowNull: false,
+    defaultValue: 0,
+  },
+});
+
+export default Tag;

--- a/src/data/models/index.js
+++ b/src/data/models/index.js
@@ -44,6 +44,8 @@ import Upload from './Upload';
 import LevelPackFavourite from './LevelPackFavourite';
 import LevelPackCollection from './LevelPackCollection';
 import LevelPackCollectionPack from './LevelPackCollectionPack';
+import Tag from './Tag';
+import ReplayTags from './ReplayTags';
 
 Replay.belongsTo(Kuski, {
   foreignKey: 'DrivenBy',
@@ -360,6 +362,18 @@ LevelPackCollectionPack.belongsTo(LevelPack, {
   as: 'PackData',
 });
 
+Tag.belongsToMany(Replay, {
+  through: ReplayTags,
+  foreignKey: 'TagIndex',
+  as: 'Replays',
+});
+
+Replay.belongsToMany(Tag, {
+  through: ReplayTags,
+  foreignKey: 'ReplayIndex',
+  as: 'Tags',
+});
+
 function sync(...args) {
   return sequelize.sync(...args);
 }
@@ -411,4 +425,5 @@ export {
   LevelPackFavourite,
   LevelPackCollection,
   LevelPackCollectionPack,
+  Tag,
 }; // add the data model here as well so it exports

--- a/src/middlewares/requireMod.js
+++ b/src/middlewares/requireMod.js
@@ -1,0 +1,9 @@
+import { authContext } from 'utils/auth';
+
+export default function requireMod(req, res, next) {
+  const auth = authContext(req);
+  if (!auth.mod) {
+    return res.sendStatus(401);
+  }
+  return next();
+}


### PR DESCRIPTION
Table definitions from test db:

```sql
CREATE TABLE `tag` (
  `TagIndex` int(11) NOT NULL AUTO_INCREMENT,
  `Name` varchar(255) NOT NULL,
  `Hidden` tinyint(1) NOT NULL DEFAULT '0',
  PRIMARY KEY (`TagIndex`),
  UNIQUE KEY `NameUniqueIndex` (`Name`)
) ENGINE=InnoDB AUTO_INCREMENT=49 DEFAULT CHARSET=utf8;
```
```sql
CREATE TABLE `replay_tags` (
  `ReplayIndex` int(11) NOT NULL,
  `TagIndex` int(11) NOT NULL,
  PRIMARY KEY (`TagIndex`,`ReplayIndex`),
  KEY `ReplayIndex` (`ReplayIndex`) USING BTREE,
  KEY `TagIndex` (`TagIndex`) USING BTREE,
  CONSTRAINT `replay_tags_ibfk_2` FOREIGN KEY (`ReplayIndex`) REFERENCES `replay` (`ReplayIndex`),
  CONSTRAINT `replay_tags_ibfk_3` FOREIGN KEY (`TagIndex`) REFERENCES `tag` (`TagIndex`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8;
```


<img width="218" alt="Screenshot 2021-03-27 at 1 27 03" src="https://user-images.githubusercontent.com/5804674/112702273-96711300-8e9b-11eb-850b-e163e5a3c52d.png">
If our `tag` table looks like this, current replay flags can be transformed to tags with (example):

```sql
INSERT INTO `eolwebtest`.`replay_tags` (ReplayIndex, TagIndex)
SELECT
    ReplayIndex,
    1
FROM
    `eolwebtest`.`replay`
WHERE
    TAS = 1;
```

etc.