### PR TITLE
feat(players): back-end for new players by country page

### DIFF
--- a/src/api/player.js
+++ b/src/api/player.js
@@ -2,7 +2,7 @@ import express from 'express';
 import { Op } from 'sequelize';
 import { like, searchLimit, searchOffset } from 'utils/database';
 import { authContext } from 'utils/auth';
-import { Team, Kuski, Ignored } from '../data/models';
+import { Team, Kuski, Ignored, Ranking } from '../data/models';
 
 const router = express.Router();
 
@@ -28,15 +28,24 @@ const Players = async () => {
   const get = await Kuski.findAll({
     attributes: ['KuskiIndex', 'Kuski', 'TeamIndex', 'Country', 'Confirmed'],
     order: [['Kuski', 'ASC']],
+    where: {
+      Confirmed: 1,
+    },
     include: [
       {
         model: Team,
         as: 'TeamData',
         attributes: ['Team'],
       },
+      {
+        model: Ranking,
+        as: 'RankingData',
+        attributes: ['PlayedAll', 'WinsAll', 'DesignedAll', 'RankingAll'],
+      },
     ],
   });
-  return get.filter(k => k.Confirmed);
+
+  return get;
 };
 
 const TeamsSearch = async (query, offset) => {

--- a/src/data/models/index.js
+++ b/src/data/models/index.js
@@ -222,9 +222,14 @@ WeeklyBest.belongsTo(WeeklyWRs, {
   as: 'WeeklyWR',
 });
 
-Ranking.belongsTo(Kuski, {
+Ranking.hasOne(Kuski, {
   foreignKey: 'KuskiIndex',
   as: 'KuskiData',
+});
+
+Kuski.hasOne(Ranking, {
+  foreignKey: 'KuskiIndex',
+  as: 'RankingData',
 });
 
 RankingYearly.belongsTo(Kuski, {

--- a/src/data/models/index.js
+++ b/src/data/models/index.js
@@ -222,7 +222,7 @@ WeeklyBest.belongsTo(WeeklyWRs, {
   as: 'WeeklyWR',
 });
 
-Ranking.hasOne(Kuski, {
+Ranking.belongsTo(Kuski, {
   foreignKey: 'KuskiIndex',
   as: 'KuskiData',
 });


### PR DESCRIPTION
Adds ranking data to the all players endpoint only. Could be added to other ones but not needed at the moment.