### PR TITLE
WIP - feat(levelpacks): redis cache test

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "node-fetch": "^2.6.1",
     "pretty-error": "^2.1.1",
     "read-chunk": "^3.2.0",
+    "redis": "^3.1.0",
     "request": "^2.88.2",
     "sequelize": "^6.3.5",
     "serialize-javascript": "^5.0.1",

--- a/src/api/allfinished.js
+++ b/src/api/allfinished.js
@@ -2,6 +2,7 @@ import express from 'express';
 import sequelize, { Op } from 'sequelize';
 import { format, subWeeks } from 'date-fns';
 import { authContext } from 'utils/auth';
+import { get, set } from 'utils/redis';
 import {
   AllFinished,
   Level,
@@ -246,7 +247,13 @@ const getLeaderHistoryForLevel = async (
 
 router
   .get('/highlight', async (req, res) => {
+    const cache = await get('allfinished-highlight');
+    if (cache) {
+      res.json(cache);
+      return;
+    }
     const data = await getHighlights();
+    set('allfinished-highlight', data, 1440);
     res.json(data);
   })
   .get('/:LevelIndex/:KuskiIndex/:limit', async (req, res) => {

--- a/src/config.js
+++ b/src/config.js
@@ -41,6 +41,11 @@ module.exports = {
     database: 'eolwebtest',
   },
 
+  redis: {
+    host: 'redis.elma.online',
+    pass: 'b14d9aca-96fe-11eb-a8b3-0242ac130003',
+  },
+
   // files
   publicFolder: '/public',
   s3SubFolder: 'test/',

--- a/src/utils/redis.js
+++ b/src/utils/redis.js
@@ -1,0 +1,49 @@
+import redis from 'redis';
+import config from '../config';
+
+const getClient = () => {
+  const redisClient = redis.createClient({
+    host: config.redis.host,
+    password: config.redis.pass,
+  });
+  redisClient.on('error', error => {
+    console.error(error);
+  });
+  return redisClient;
+};
+
+export const set = (key, value, expire = 0) => {
+  try {
+    const client = getClient();
+    const stringValue =
+      typeof value === 'object' ? JSON.stringify(value) : value;
+    client.set(key, stringValue);
+    if (expire) {
+      client.expire(key, expire * 60);
+    }
+    client.quit();
+    return '';
+  } catch (error) {
+    return { error };
+  }
+};
+
+export const get = key => {
+  return new Promise((resolve, reject) => {
+    const client = getClient();
+    client.get(key, (err, value) => {
+      let objectValue = '';
+      try {
+        objectValue = JSON.parse(value);
+      } catch (e) {
+        objectValue = value;
+      }
+      if (err) {
+        reject(err);
+      } else {
+        resolve(objectValue);
+      }
+      client.quit();
+    });
+  });
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4028,7 +4028,7 @@ delayed-stream@~1.0.0:
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
-denque@^1.4.1:
+denque@^1.4.1, denque@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/denque/-/denque-1.5.0.tgz#773de0686ff2d8ec2ff92914316a47b73b1c73de"
   integrity sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ==
@@ -9912,6 +9912,33 @@ redent@^2.0.0:
   dependencies:
     indent-string "^3.0.0"
     strip-indent "^2.0.0"
+
+redis-commands@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/redis-commands/-/redis-commands-1.7.0.tgz#15a6fea2d58281e27b1cd1acfb4b293e278c3a89"
+  integrity sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==
+
+redis-errors@^1.0.0, redis-errors@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/redis-errors/-/redis-errors-1.2.0.tgz#eb62d2adb15e4eaf4610c04afe1529384250abad"
+  integrity sha1-62LSrbFeTq9GEMBK/hUpOEJQq60=
+
+redis-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-3.0.0.tgz#b66d828cdcafe6b4b8a428a7def4c6bcac31c8b4"
+  integrity sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=
+  dependencies:
+    redis-errors "^1.0.0"
+
+redis@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/redis/-/redis-3.1.0.tgz#39daec130d74b78decca93513c61db0af5d86ce6"
+  integrity sha512-//lAOcEtNIKk2ekZibes5oyWKYUVWMvMB71lyD/hS9KRePNkB7AU3nXGkArX6uDKEb2N23EyJBthAv6pagD0uw==
+  dependencies:
+    denque "^1.5.0"
+    redis-commands "^1.7.0"
+    redis-errors "^1.2.0"
+    redis-parser "^3.0.0"
 
 reduce-css-calc@^2.1.5:
   version "2.1.8"


### PR DESCRIPTION
See frontend part here https://github.com/elmadev/elmaonline-web/compare/redis-test?expand=1

First test with some redis cache. There's two different approaches.

On levelpack/:LevelPackName/stats it will return the cache if cache query param is defined, otherwise get from db and update the cache. This is done so frontend can get cache first to show something and then get newest version and update the page. Often when you check this page it's because you've made some new times, so you don't want something that's an hour old or even five minutes old. With this approach the page will load very fast and then if there has been any updates since last cache it'll be visible a few seconds later. The approach through easy-peasy is not super elegant so any ideas is welcome.

On allfinishes/highlight it uses a cache with an expire, meaning it will always return cache if it exists, after expire it will make the database call again and set new cache. This is data that doesn't really matter if it's some hours old since it's used to define which times to highlight.