### PR TITLE
feat(discord): link to level in times

### DIFF
--- a/src/utils/discord/discord.js
+++ b/src/utils/discord/discord.js
@@ -84,6 +84,10 @@ const alignTime = time => {
   return alignedTime;
 };
 
+const linkLevel = (name, id) => {
+  return `[${name}](https://elma.online/levels/${id})`;
+};
+
 const formatLevel = level => {
   if (
     level.substring(0, 6) === 'QWQUU0' &&
@@ -164,8 +168,9 @@ function discordChatline(content) {
 
 function discordBesttime(content) {
   if (!content.battleIndex) {
-    let text = `${formatLevel(content.level)}:`;
-    text += ` ${content.time} by ${content.kuski} (${content.position}.)`;
+    const level = formatLevel(content.level);
+    const linkedLevel = linkLevel(level, content.levelIndex);
+    let text = `${linkedLevel}: ${content.time} by ${content.kuski} (${content.position}.)`;
     if (content.position === 1) {
       text += ' :first_place:';
     }
@@ -174,12 +179,13 @@ function discordBesttime(content) {
 }
 
 function discordBestmultitime(content) {
+  const level = formatLevel(content.level);
+  const linkedLevel = linkLevel(level, content.levelIndex);
+
   if (!content.battleIndex) {
     sendMessage(
       config.discord.channels.times,
-      `${formatLevel(content.level)}: ${content.time} (M) by ${
-        content.kuski1
-      } & ${content.kuski2} (${content.position}.)`,
+      `${linkedLevel}: ${content.time} (M) by ${content.kuski1} & ${content.kuski2} (${content.position}.)`,
     );
   }
 }


### PR DESCRIPTION
would def request a review on this as I don't know how to test it or if it even works as intended.

apparently, you can write custom links using format described here: https://support.discord.com/hc/en-us/community/posts/360061776032-How-to-make-clickable-text-hyperlink-

but only works using discord chat bot.

Also, the functions were hard to test because they both build the message and sent it at the same time. So the best I could do was take the json examples from /events and feed them into the functions and console log their output, which is below.

![image](https://user-images.githubusercontent.com/24510397/115506069-6e7d9100-a248-11eb-8ee4-3d19d4496ed2.png)
