### PR TITLE
feat(levelpack): faster query for records, and in its own endpoint

### DIFF
--- a/src/data/models/PlayStats.js
+++ b/src/data/models/PlayStats.js
@@ -265,7 +265,7 @@ const maxGroup = (times, base, col) => {
 };
 
 // convert time.Driven to unix timestamp
-const parseTimeDriven = d => {
+export const parseTimeDriven = d => {
   let parsed = parseInt(moment(d).format('X'), 10);
   if (Number.isNaN(parsed)) {
     parsed = 0;


### PR DESCRIPTION
The old stats endpoint queried for records, king list and total times, which was a lot of work for the internal levelpack. So I added a new endpoint which only gets the records and uses some optimized SQL. It doesn't use the ORM since the ORM doesn't generate a very optimized query. I don't know how fast SQL vs. ORM is, but the front-end can hopefully get internal levelpack records in a few seconds now as compared to 10s or more as it was before when the endpoint was also doing the other stuff.

The old stats endpoint was not removed as its still used for most tabs in the client.