### PR TITLE
fix(crippled): remove unnecessary battle index column

### DIFF
--- a/src/api/crippled.js
+++ b/src/api/crippled.js
@@ -139,7 +139,7 @@ const getKuskiTimes = async (LevelIndex, KuskiIndex, CrippledType) => {
 
   // very fast when KuskiIndex provided
   const kuskiTimes = await Crippled.findAll({
-    attributes: ['TimeIndex', 'BattleIndex', 'Time', 'Driven'],
+    attributes: ['TimeIndex', 'Time', 'Driven'],
     where: {
       LevelIndex,
       KuskiIndex,


### PR DESCRIPTION
Not sure if production server has a battleIndex column in the crippled table, but since it's not on dev this is causing some errors which prevents data from being shown on client.