### PR TITLE
feat(levelpack): cache all packs stats query (in memory for now)

### DIFF
--- a/src/api/levelpack.js
+++ b/src/api/levelpack.js
@@ -954,6 +954,25 @@ const allPacksStats = async () => {
   return stats;
 };
 
+// memory cache for allPacksStats (used on /levels).
+// note that on hot-reload this will get re-initialized,
+// even if you save files other than this one. That's not
+// ideal for development, but I think it's a worthy trade-off
+// for production.
+const statsCache = {
+  time: 0,
+  data: [],
+};
+
+const updateStatsCache = async () => {
+  const stats = await allPacksStats();
+  statsCache.time = new Date().getTime();
+  statsCache.data = stats;
+
+  // might end up ignoring the return value
+  return stats;
+};
+
 // @see https://express-validator.github.io/docs/schema-validation.html
 // /update uses these except for LevelPackName.
 // /add could use these but it already had client-side validation so for
@@ -1014,8 +1033,18 @@ router
     res.json(packs);
   })
   .get('/stats', async (req, res) => {
-    const stats = await allPacksStats();
-    res.json(stats);
+
+    // we'll cache the data in memory (filesize 4.1kb last I checked)
+    const refresh = 60 * 60 * 1000;
+    const now = new Date().getTime();
+
+    // just update the cache for next time, it's ok to serve data that
+    // is a bit stale.
+    if ( now - statsCache.time > refresh ) {
+      updateStatsCache();
+    }
+
+    res.json(statsCache.data);
   })
   .get('/level-stats/:byName/:identifier', async (req, res) => {
     let LevelPackIndex;

--- a/src/utils/dataImports.js
+++ b/src/utils/dataImports.js
@@ -16,7 +16,7 @@ import {
   Country,
   Team,
 } from '../data/models';
-import * as kuskiMapData from '../data/json/kuskimap.json';
+import * as kuskiMapData from '../data/json/kuskimap.json' assert {type: "json"};
 
 const api = create({
   baseURL: 'https://eol.ams3.digitaloceanspaces.com/import/',

--- a/src/utils/dataImports.js
+++ b/src/utils/dataImports.js
@@ -16,7 +16,7 @@ import {
   Country,
   Team,
 } from '../data/models';
-import * as kuskiMapData from '../data/json/kuskimap.json' assert {type: "json"};
+import * as kuskiMapData from '../data/json/kuskimap.json';
 
 const api = create({
   baseURL: 'https://eol.ams3.digitaloceanspaces.com/import/',


### PR DESCRIPTION
I decided to do this in memory for now. I don't think I usually end up mutating any variables in a module like this, but I think it will work fine in production. Let me know if you think otherwise. In dev it works fine, but if you save any file, the hot-reload will cause the module to get re-initialized, so the variable will take on its default value again.

Also the reason I decided to use in memory is because I haven't used node in a while and i'm not too familiar with the file system stuff, so I thought this would be easier for now. If you prefer just let me know and i'll use a file instead. (can probably just stick it in /data/json, where the kuskiMap data is)

Note that the method of caching here prefers a fast query basically always, so it could serve stale data, but I think for now that might be better than how it works where the query is often very slow. It basically means when you load the page, you'll see the data from whoever loaded it last before you. And then if you load it again in 5-10s it should be up to date. So how good/bad this works depends on how many people load the page overall I guess.

I also removed "assert {type: "json"}" when importing the kuski map. For some reason I got an error saying it wasn't of type JSON, even though the file existed and clearly was a JSON file. Not sure why. Hope it's not necessary to assert the type there. Maybe i'll quickly check it and make sure its not broken though.