### PR TITLE
feat(settings): add battle notifier settings

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "printWidth": 80,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "arrowParens": "avoid"
+}

--- a/src/config.defaults.js
+++ b/src/config.defaults.js
@@ -49,7 +49,8 @@ export default {
 
   // auth
   // eslint-disable-next-line prettier/prettier
-  jwtSecret: 'eAwI4zcTDd4Pvc8QtN9z57Fqsr4ENNcTpK1x4A1dCLj0Y44OravXZDzNbA-4VEwAIh1Hw3vn1nhB9ygWLqAGE4GiX6hjjLsJi8IJ',
+  jwtSecret:
+    'eAwI4zcTDd4Pvc8QtN9z57Fqsr4ENNcTpK1x4A1dCLj0Y44OravXZDzNbA-4VEwAIh1Hw3vn1nhB9ygWLqAGE4GiX6hjjLsJi8IJ',
   jwtAlgo: 'HS256',
   recaptcha: {
     client: '6Le-n9QUAAAAAG-3bYyysXddxwD6I6iJeDBTHf2r',
@@ -76,6 +77,7 @@ export default {
       admin: 'admin',
     },
     apiAuth: '', // Authorization header sent by game events
-    url: 'https://test.elma.online/', // url used in discord messages
+    url: 'https://test.elma.online/', // url used in discord messages,
+    bnAuth: 'e5f13420-cf17-4fd5-8cc9-c96959d1048f', // Authorization header sent from BN
   },
 };

--- a/src/data/models/BnKuskiRule.js
+++ b/src/data/models/BnKuskiRule.js
@@ -1,0 +1,53 @@
+import DataType from 'sequelize';
+import Model from '../sequelize';
+
+const Setting = Model.define('bn_kuski_rule', {
+  BnKuskiRuleIndex: {
+    type: DataType.INTEGER,
+    autoIncrement: true,
+    allowNull: false,
+    primaryKey: true,
+  },
+  KuskiIndex: {
+    type: DataType.INTEGER,
+    allowNull: false,
+    defaultValue: 0,
+  },
+  BattleTypes: {
+    type: DataType.STRING(255),
+    allowNull: true,
+    defaultValue: null,
+  },
+  Designers: {
+    type: DataType.STRING(255),
+    allowNull: true,
+    defaultValue: null,
+  },
+  LevelPatterns: {
+    type: DataType.STRING(255),
+    allowNull: true,
+    defaultValue: null,
+  },
+  BattleAttributes: {
+    type: DataType.STRING(255),
+    allowNull: true,
+    defaultValue: null,
+  },
+  MinDuration: {
+    type: DataType.INTEGER,
+    allowNull: true,
+    defaultValue: 0,
+  },
+  MaxDuration: {
+    type: DataType.INTEGER,
+    allowNull: true,
+    defaultValue: 0,
+  },
+  IgnoreList: {
+    type: DataType.INTEGER,
+    allowNull: false,
+    defaultValue: 0,
+  },
+});
+
+export default Setting;

--- a/src/data/models/Setting.js
+++ b/src/data/models/Setting.js
@@ -60,6 +60,11 @@ const Setting = Model.define(
       allowNull: false,
       defaultValue: 1,
     },
+    BnEnabled: {
+      type: DataType.INTEGER,
+      allowNull: false,
+      defaultValue: 0,
+    },
   },
   {
     indexes: [

--- a/src/data/models/index.js
+++ b/src/data/models/index.js
@@ -59,6 +59,7 @@ import MultiTimeFile from './MultiTimeFile';
 import Crippled from './Crippled';
 import Recap from './Recap';
 import ReplayLog from './ReplayLog';
+import BnKuskiRule from './BnKuskiRule';
 
 Replay.belongsTo(Kuski, {
   foreignKey: 'DrivenBy',
@@ -511,6 +512,18 @@ Recap.belongsTo(Replay, {
   as: 'ReplayData',
 });
 
+Setting.hasMany(BnKuskiRule, {
+  foreignKey: 'KuskiIndex',
+  sourceKey: 'KuskiIndex',
+  as: 'BnKuskiRules',
+});
+
+BnKuskiRule.belongsTo(Setting, {
+  foreignKey: 'KuskiIndex',
+  targetKey: 'KuskiIndex',
+  as: 'SettingData',
+});
+
 function sync(...args) {
   return sequelize.sync(...args);
 }
@@ -576,4 +589,6 @@ export {
   Crippled,
   Recap,
   ReplayLog,
+  ReplayTags,
+  BnKuskiRule,
 }; // add the data model here as well so it exports

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -80,10 +80,7 @@ export const auth = async body => {
     };
   }
   if (kuskiData.dataValues.Password) {
-    const md5 = crypto
-      .createHash('md5')
-      .update(password)
-      .digest('hex');
+    const md5 = crypto.createHash('md5').update(password).digest('hex');
     if (md5 === kuskiData.dataValues.Password) {
       if (kuskiData.dataValues.Salt) {
         await addSha3(
@@ -123,4 +120,11 @@ export function authContext(req) {
     }
   }
   return { auth: false, userid: 0 };
+}
+
+export function authDiscord(req, res, next) {
+  if (req.header('Authorization') === config.discord.bnAuth) {
+    return next();
+  }
+  return res.sendStatus(401);
 }


### PR DESCRIPTION
Battle Notifier migration discussion [here](https://github.com/elmadev/elmaonline-site/issues/474).

## What changes are proposed in this pull request?

Add new `bn_kuski_rule` table and update `setting` table to store notification settings.

```js
- setting
  + BnEnabled: boolean // turn notifications on/off 
```

```js
+ bn_kuski_rule
  + BnKuskiRuleIndex: number
  + KuskiIndex: number // multiple rules per kuski
  + BattleTypes: string // Normal,First Finish,One Life
  + Designers: string // Kopaka,Igge
  + LevelPatterns: string // Pob.lev,jbl.lev
  + BattleAttributes string // see others,drunk 
  + MinDuration: number // minutes
  + MaxDuration: number // minutes
  + IgnoreList: boolean // is rule for ignore list
```

- Endpoints:
  - `GET api/bn/:DiscordId` - get user settings if `DiscordId` exists in DB.
  - `SET api/bn/:DiscordId` - override user notification rules
    - First time the user sets notification rules, settings `BnEnabled` should be set to true. 
  - `GET api/bn` - gets all "active" settings with `BnEnabled` and at least one `BnKuskiRule`
  - `SET api/bn/:DiscordId/toggle/:BnEnabled` - turn notifications on/off (`BnEnabled`)
  - `GET api/bn/:DiscordId/linked` - does `DiscordId` exist in DB

