### PR TITLE
Improve tag system + add new level search

### DIFF
--- a/src/api/level.js
+++ b/src/api/level.js
@@ -173,6 +173,7 @@ const getLevels = async (
   LevelPackIndex = 0,
   excludedTags = [],
   finished = 'all',
+  battled = 'all',
 ) => {
   const getOrder = () => {
     if (sortBy === 'rating') {
@@ -239,10 +240,21 @@ const getLevels = async (
     ...isFinishedCondition,
   };
 
+  // Battled filter
+  const having =
+    battled !== 'all'
+      ? {
+          BattleCount: {
+            [battled === 'true' ? sequelize.Op.gt : sequelize.Op.eq]: 0,
+          },
+        }
+      : {};
+
   const data = await Level.findAll({
     limit: searchLimit(limit),
     offset: searchOffset(offset),
     where,
+    having,
     order: getOrder(),
     attributes: [
       'LevelIndex',
@@ -347,6 +359,7 @@ router.get('/', async (req, res) => {
     req.query.levelPack,
     req.query.excludedTags,
     req.query.finished,
+    req.query.battled,
   );
   res.json(data);
 });

--- a/src/api/level.js
+++ b/src/api/level.js
@@ -14,7 +14,7 @@ import {
   Besttime,
 } from '../data/models';
 import connection from '../data/sequelize';
-import { fromToTime, searchLimit, searchOffset } from '#utils/database';
+import { fromToTime, searchLimit, searchOffset, like } from '#utils/database';
 
 const router = express.Router();
 
@@ -181,6 +181,7 @@ const getLevels = async (
   finished = 'all',
   battled = 'all',
   finishedBy = 0,
+  query = '',
 ) => {
   // Don't show hidden levels in search.
   // Showing them makes hiding finishedBy filtering slow.
@@ -192,6 +193,14 @@ const getLevels = async (
       where = { AddedBy, Locked: 0, Hidden: 0 };
     }
   }
+
+  // Search term
+  where = {
+    ...where,
+    LevelName: {
+      [sequelize.Op.like]: `${like(query)}%`,
+    },
+  };
 
   // // Filter by level pack
   // let packLevels = [];
@@ -387,6 +396,7 @@ router.get('/', async (req, res) => {
     req.query.finished,
     req.query.battled,
     req.query.finishedBy,
+    req.query.q,
   );
   res.json(data);
 });

--- a/src/api/level.js
+++ b/src/api/level.js
@@ -202,17 +202,19 @@ const getLevels = async (
     },
   };
 
-  // // Filter by level pack
-  // let packLevels = [];
-  // if (LevelPackIndex) {
-  //   packLevels = await LevelPackLevel.findAll({
-  //     attributes: ['LevelIndex'],
-  //     where: {
-  //       LevelPackIndex,
-  //     },
-  //   }).then(data => data.map(r => r.LevelIndex));
-  // }
-  // const levelWhere = packLevels.length ? { LevelIndex: packLevels } : {};
+  // Filter by level pack
+  let packLevels = [];
+
+  if (LevelPackIndex) {
+    const data = await LevelPackLevel.findAll({
+      attributes: ['LevelIndex'],
+      where: {
+        LevelPackIndex,
+      },
+    });
+
+    packLevels = data.map(r => r.LevelIndex);
+  }
 
   // Compicated stuff. Review and recheck.
   const getFinishedByFinishedLevels = async finishedBy => {
@@ -241,6 +243,11 @@ const getLevels = async (
   const excludeFinishedByLevelIndexes = finishedBy && finished === 'false';
 
   const getInIndexes = () => {
+    // Filter by levelpacks
+    if (packLevels.length) {
+      return packLevels;
+    }
+
     if (tags.length && includeFinishedByLevelIndexes) {
       return intersection(levelIndexesByTags, levelIndexesByFinishedBy);
     }
@@ -272,11 +279,13 @@ const getLevels = async (
     return null;
   };
 
-  if (tags.length || excludedTags.length || finishedBy) {
+  if (tags.length || excludedTags.length || finishedBy || LevelPackIndex) {
     where = {
       ...where,
       LevelIndex: {
-        ...((tags.length || includeFinishedByLevelIndexes) && {
+        ...((tags.length ||
+          includeFinishedByLevelIndexes ||
+          LevelPackIndex) && {
           [sequelize.Op.in]: getInIndexes(),
         }),
         ...((excludedTags.length || excludeFinishedByLevelIndexes) && {

--- a/src/api/level.js
+++ b/src/api/level.js
@@ -387,8 +387,12 @@ router.get('/kuskis', async (req, res) => {
 router.get('/', async (req, res) => {
   const offset = req.query.pageSize * req.query.page || 0;
   const limit = req.query.pageSize;
-  // const addedBy = 0;
-  const userId = 0;
+
+  const auth = authContext(req);
+  let userId = 0;
+  if (auth.auth) {
+    userId = auth.userid;
+  }
 
   const data = await getLevels(
     offset,

--- a/src/api/level.js
+++ b/src/api/level.js
@@ -252,6 +252,13 @@ const getLevels = async (
       'Killers',
       'Flowers',
       'Added',
+      [
+        sequelize.literal(
+          '(SELECT COUNT(*) FROM battle WHERE battle.LevelIndex = level.LevelIndex)',
+        ),
+        'BattleCount',
+      ],
+
       //   include: [
       //     [
       //       sequelize.literal(`(

--- a/src/api/level.js
+++ b/src/api/level.js
@@ -162,6 +162,20 @@ router.post('/:LevelIndex', async (req, res) => {
   }
 });
 
+router.post('/:LevelIndex/tags', async (req, res) => {
+  const auth = authContext(req);
+
+  const level = await Level.findByPk(req.params.LevelIndex);
+
+  if (auth.mod || auth.userid === level.AddedBy) {
+    await level.setTags(req.body.Tags);
+    const response = await getLevel(req.params.LevelIndex, 1);
+    res.json(response);
+  } else {
+    res.sendStatus(401);
+  }
+});
+
 router.get('/leveldata/:LevelIndex', async (req, res) => {
   const data = await getLevelData(req.params.LevelIndex);
   res.json(data);

--- a/src/api/level.js
+++ b/src/api/level.js
@@ -148,23 +148,27 @@ const getLevelIndexesByTags = async (tags, onlyOneMatchIsEnough = false) => {
     query = `
       SELECT DISTINCT level_tags.LevelIndex
       FROM level_tags, level
-      WHERE level_tags.TagIndex IN (${tags.join()})
+      WHERE level_tags.TagIndex IN (:tags)
 	    AND level_tags.LevelIndex = level.LevelIndex
       GROUP BY level_tags.LevelIndex
-      HAVING COUNT(level_tags.TagIndex) >= ${compareCount};`;
+      HAVING COUNT(level_tags.TagIndex) >= :compareCount;`;
   }
 
   if (query) {
-    const [levelIndexes] = await connection.query(query);
+    const [levelIndexes] = await connection.query(query, {
+      replacements: { tags, compareCount },
+    });
     return levelIndexes.map(l => l.LevelIndex);
   }
   return [];
 };
 
 const getLevelIndexesByFinishedBy = async finishedBy => {
-  const query = `SELECT LevelIndex from besttime WHERE KuskiIndex = ${finishedBy}`;
+  const query = `SELECT LevelIndex from besttime WHERE KuskiIndex = :finishedBy`;
 
-  const [levelIndexes] = await connection.query(query);
+  const [levelIndexes] = await connection.query(query, {
+    replacements: { finishedBy },
+  });
   return levelIndexes.map(l => l.LevelIndex);
 };
 

--- a/src/api/level.js
+++ b/src/api/level.js
@@ -308,6 +308,21 @@ const getLevels = async (
   };
 };
 
+const getKuskisWhoAddedLevels = async () => {
+  const query = `
+    SELECT DISTINCT kuski.KuskiIndex, kuski.Kuski
+    FROM kuski
+    JOIN level ON kuski.KuskiIndex = level.AddedBy`;
+
+  const [kuskis] = await connection.query(query);
+  return kuskis;
+};
+
+router.get('/kuskis', async (req, res) => {
+  const data = await getKuskisWhoAddedLevels();
+  res.json(data);
+});
+
 router.get('/', async (req, res) => {
   const offset = req.query.pageSize * req.query.page || 0;
   const limit = req.query.pageSize;

--- a/src/api/level.js
+++ b/src/api/level.js
@@ -3,7 +3,7 @@ import sequelize from 'sequelize';
 import { authContext } from '#utils/auth';
 import { has } from 'lodash-es';
 import { getLevel as getLevelSecure } from '#utils/download';
-import { Level, Time, LevelStats, Battle } from '../data/models';
+import { Level, Time, LevelStats, Battle, Tag } from '../data/models';
 import connection from '../data/sequelize';
 import { fromToTime } from '#utils/database';
 
@@ -33,28 +33,37 @@ const getLevel = async (LevelIndex, withStats = false) => {
   );
 
   if (withStats && ongoingBattles.length === 0) {
-    include.push({
-      attributes: [
-        'TimeF',
-        'TimeE',
-        'TimeD',
-        'TimeAll',
-        'AttemptsF',
-        'AttemptsE',
-        'AttemptsD',
-        'AttemptsAll',
-        'MaxSpeedF',
-        'MaxSpeedE',
-        'MaxSpeedD',
-        'MaxSpeedAll',
-        'LeaderCount',
-        'UniqueLeaderCount',
-        'KuskiCountF',
-        'KuskiCountAll',
-      ],
-      model: LevelStats,
-      as: 'LevelStatsData',
-    });
+    include.push(
+      {
+        attributes: [
+          'TimeF',
+          'TimeE',
+          'TimeD',
+          'TimeAll',
+          'AttemptsF',
+          'AttemptsE',
+          'AttemptsD',
+          'AttemptsAll',
+          'MaxSpeedF',
+          'MaxSpeedE',
+          'MaxSpeedD',
+          'MaxSpeedAll',
+          'LeaderCount',
+          'UniqueLeaderCount',
+          'KuskiCountF',
+          'KuskiCountAll',
+        ],
+        model: LevelStats,
+        as: 'LevelStatsData',
+      },
+      {
+        model: Tag,
+        as: 'Tags',
+        through: {
+          attributes: [],
+        },
+      },
+    );
   }
 
   const level = await Level.findOne({

--- a/src/api/level.js
+++ b/src/api/level.js
@@ -316,7 +316,6 @@ const getLevels = async (
   };
 
   const data = await Level.findAll({
-    subQuery: false,
     limit: searchLimit(limit),
     offset: searchOffset(offset),
     where,
@@ -365,7 +364,7 @@ const getLevels = async (
 
 const getKuskisWhoAddedLevels = async () => {
   const query = `
-    SELECT DISTINCT kuski.KuskiIndex, kuski.Kuski
+    SELECT DISTINCT kuski.KuskiIndex, kuski.Kuski, kuski.Country
     FROM kuski
     JOIN level ON kuski.KuskiIndex = level.AddedBy`;
 

--- a/src/api/levelpack.js
+++ b/src/api/levelpack.js
@@ -35,6 +35,7 @@ import {
   BestMultitime,
   LegacyBesttime,
   Battle,
+  Tag,
 } from '../data/models';
 import Admin from './levelpack_admin';
 import Favourite from './levelpack_favourite';
@@ -779,7 +780,16 @@ const AddLevelPack = async data => {
 export const getPackByName = async LevelPackName => {
   const packInfo = await LevelPack.findOne({
     where: { LevelPackName },
-    include: [{ model: Kuski, as: 'KuskiData', attributes: ['Kuski'] }],
+    include: [
+      { model: Kuski, as: 'KuskiData', attributes: ['Kuski'] },
+      {
+        model: Tag,
+        as: 'Tags',
+        through: {
+          attributes: [],
+        },
+      },
+    ],
   });
   return packInfo;
 };

--- a/src/api/levelpack.js
+++ b/src/api/levelpack.js
@@ -797,7 +797,16 @@ export const getPackByName = async LevelPackName => {
 export const getPackByIndex = async LevelPackIndex => {
   const packInfo = await LevelPack.findOne({
     where: { LevelPackIndex },
-    include: [{ model: Kuski, as: 'KuskiData', attributes: ['Kuski'] }],
+    include: [
+      { model: Kuski, as: 'KuskiData', attributes: ['Kuski'] },
+      {
+        model: Tag,
+        as: 'Tags',
+        through: {
+          attributes: [],
+        },
+      },
+    ],
   });
   return packInfo;
 };
@@ -1349,6 +1358,9 @@ router
       pack.LevelPackDesc = req.body.LevelPackDesc;
 
       await pack.save();
+      await pack.setTags(req.body.Tags);
+      await pack.reload();
+
       res.json({
         success: true,
         LevelPack: pack,

--- a/src/api/tag.js
+++ b/src/api/tag.js
@@ -5,9 +5,9 @@ import requireMod from '../middlewares/requireMod';
 
 const router = express.Router();
 
-const getTags = async () => {
+const getTags = async Type => {
   const data = await Tag.findAll();
-  return data;
+  return data.filter(tag => (Type ? Type === tag.Type : true));
 };
 
 const createTag = async data => {
@@ -27,7 +27,7 @@ const deleteTag = async id => {
 
 router
   .get('/', async (req, res) => {
-    const data = await getTags();
+    const data = await getTags(req.query.type);
     res.json(data);
   })
   .post('/', requireMod, async (req, res) => {

--- a/src/data/models/LevelPackTags.js
+++ b/src/data/models/LevelPackTags.js
@@ -1,0 +1,17 @@
+import DataType from 'sequelize';
+import Model from '../sequelize';
+
+const LevelPackTags = Model.define('levelpack_tags', {
+  TagIndex: {
+    type: DataType.INTEGER,
+    allowNull: false,
+    defaultValue: false,
+  },
+  LevelPackIndex: {
+    type: DataType.INTEGER,
+    allowNull: false,
+    defaultValue: false,
+  },
+});
+
+export default LevelPackTags;

--- a/src/data/models/LevelTags.js
+++ b/src/data/models/LevelTags.js
@@ -1,0 +1,17 @@
+import DataType from 'sequelize';
+import Model from '../sequelize';
+
+const LevelTags = Model.define('level_tags', {
+  TagIndex: {
+    type: DataType.INTEGER,
+    allowNull: false,
+    defaultValue: false,
+  },
+  LevelIndex: {
+    type: DataType.INTEGER,
+    allowNull: false,
+    defaultValue: false,
+  },
+});
+
+export default LevelTags;

--- a/src/data/models/Tag.js
+++ b/src/data/models/Tag.js
@@ -17,6 +17,11 @@ const Tag = Model.define('tag', {
     allowNull: false,
     defaultValue: 0,
   },
+  Type: {
+    type: DataType.ENUM,
+    values: ['replay', 'level', 'levelpack'],
+    allowNull: false,
+  },
 });
 
 export default Tag;

--- a/src/data/models/index.js
+++ b/src/data/models/index.js
@@ -181,6 +181,8 @@ Level.hasOne(LevelStats, {
   constraints: false,
 });
 
+Level.hasOne(Besttime, { foreignKey: 'LevelIndex', as: 'Besttime' });
+
 Level.belongsToMany(Tag, {
   through: LevelTags,
   foreignKey: 'LevelIndex',

--- a/src/data/models/index.js
+++ b/src/data/models/index.js
@@ -3,6 +3,7 @@ import Battle from './Battle'; // add the data model here to import
 import Replay from './Replay';
 import Level from './Level';
 import LevelTags from './LevelTags';
+import LevelPackTags from './LevelPackTags';
 import Kuski from './Kuski';
 import Battletime from './Battletime';
 import BattleLeague from './BattleLeague';
@@ -201,6 +202,18 @@ LevelStats.belongsTo(Level, {
 LevelPack.hasMany(LevelPackLevel, {
   foreignKey: 'LevelPackIndex',
   as: 'Levels',
+});
+
+LevelPack.belongsToMany(Tag, {
+  through: LevelPackTags,
+  foreignKey: 'LevelPackIndex',
+  as: 'Tags',
+});
+
+Tag.belongsToMany(LevelPack, {
+  through: LevelPackTags,
+  foreignKey: 'TagIndex',
+  as: 'LevelPacks',
 });
 
 LevelPackLevel.belongsTo(Level, {

--- a/src/data/models/index.js
+++ b/src/data/models/index.js
@@ -2,6 +2,7 @@ import sequelize from '../sequelize';
 import Battle from './Battle'; // add the data model here to import
 import Replay from './Replay';
 import Level from './Level';
+import LevelTags from './LevelTags';
 import Kuski from './Kuski';
 import Battletime from './Battletime';
 import BattleLeague from './BattleLeague';
@@ -177,6 +178,18 @@ Level.hasOne(LevelStats, {
   foreignKey: 'LevelIndex',
   as: 'LevelStatsData',
   constraints: false,
+});
+
+Level.belongsToMany(Tag, {
+  through: LevelTags,
+  foreignKey: 'LevelIndex',
+  as: 'Tags',
+});
+
+Tag.belongsToMany(Level, {
+  through: LevelTags,
+  foreignKey: 'TagIndex',
+  as: 'Levels',
 });
 
 LevelStats.belongsTo(Level, {


### PR DESCRIPTION
- Added tags for levels and levelpacks
- Created new endpoint `GET /levels` which returns list of levels filtered by given query params

> [!IMPORTANT]
> Needs the following changes to database.

- `tag`
   - Add `Type`
   - Change uniqueIndex from `Name` -> `Name+Type`
- `level_tags`
  - Create table
- `levelpack_tags`
  - Create table
- `level`
  - Add index to `AddedBy`

