### PR TITLE
Level collection stats

### DIFF
--- a/src/config.local.js
+++ b/src/config.local.js
@@ -8,4 +8,6 @@ if (process.env.BROWSER) {
 
 // add keys from defaults.js that you want to change the value for
 // changes to this file will not be seen by git
-export default {};
+export default {
+  port: 3008
+};

--- a/src/data/models/LevelStats.js
+++ b/src/data/models/LevelStats.js
@@ -1,5 +1,5 @@
 import Sequelize, { Model } from 'sequelize';
-import { includes, range, toPairs, uniqBy, isEmpty } from 'lodash-es';
+import { includes, range, toPairs, uniqBy, isEmpty, omit } from 'lodash-es';
 import * as PlayStats from './PlayStats.js';
 import sequelize from '../sequelize.js';
 import { getPerfTracker } from '#utils/perf';
@@ -162,6 +162,13 @@ const cols = toPairs(ddl)
 export const defaultAttributes = () => {
   return cols.concat('TopXTimes');
 };
+
+export const getColsForCollectionStats = () => {
+  // just omit some cols that might contain a lot of data for ints
+  return cols.filter(col => {
+    return !includes(['LeaderHistory', 'KuskiIdsF', 'KuskiIdsAll'], col);
+  });
+}
 
 class LevelStats extends Model {
   // map an array of ids to existing instances or null


### PR DESCRIPTION
Adds an endpoint to get level stats for a collection of levels...

right now just supports passing level IDs, which is good enough.

Used for 2 new pages currently: Level pack play stats tab, Cup play stats tab.