### PR TITLE
fix(levels): add missing attributes for replay preview

### DIFF
--- a/src/api/allfinished.js
+++ b/src/api/allfinished.js
@@ -114,13 +114,30 @@ export const getTimes = async (LevelIndex, KuskiIndex, limit, LoggedIn = 0) => {
     ];
   }
 
+  const attributes = ['TimeIndex', 'Time', 'Apples', 'Driven', 'FPSLimit'];
+
+  if (personal) {
+    attributes.push(
+      'Finished',
+      'BattleIndex',
+      'MaxSpeed',
+      'ThrottleTime',
+      'BrakeTime',
+      'LeftVolt',
+      'RightVolt',
+      'SuperVolt',
+      'Turn',
+      'OneWheel',
+    );
+  }
+
   const times = await AllFinished.findAll({
     where: { LevelIndex, KuskiIndex },
     order: [
       ['Time', 'ASC'],
       ['TimeIndex', 'ASC'],
     ],
-    attributes: ['TimeIndex', 'Time', 'Apples', 'Driven'],
+    attributes,
     limit: timeLimit > 10000 ? 10000 : timeLimit,
     include,
   });


### PR DESCRIPTION
Needed when watching replay preview from "My times" tab on level page. Fixes https://github.com/elmadev/elmaonline-site/issues/768.

Successfuly tested API responses locally against test server db.