### PR TITLE
fix(levels): fix legacy times sorting

### DIFF
--- a/src/api/allfinished.js
+++ b/src/api/allfinished.js
@@ -143,7 +143,7 @@ export const getTimes = async (LevelIndex, KuskiIndex, limit, LoggedIn = 0) => {
       include: includeLegacy,
     });
     return [...times, ...legacyTimes]
-      .sort((a, b) => a.Time - b.Time)
+      .sort((a, b) => a.Time - b.Time || a.Driven - b.Driven)
       .slice(0, parseInt(limit, 10));
   }
   return times;


### PR DESCRIPTION
Fixes https://github.com/elmadev/elmaonline-site/issues/775.

I ended up with this solution as it seemed the most elegant. What it does is just a secondary sort by Driven for equal times, which will correctly put legacy times before eol times (also sorts equal legacy times correctly among themselves as we don't sort them when querying). Afaik this change also re-sorts eol time vs eol time by Driven if it's equal, which was already sorted previously by TimeIndex when querying, but this shouldn't change anything in practice and other solutions seemed too convoluted. Technically we can even drop the initial sort by Time + TimeIndex for eol times, as we are sorting all times by Time + Driven later anyway, but i kept it there for now.

Alternative solution:
1. Sort eol times by Time + TimeIndex when querying (we already do that).
2. Sort legacy times by Time + Driven when querying.
3. Don't combine times with spread operator, but merge the two arrays and sort identical times between arrays by Driven (as we know which time is eol time and which is legacy time).

The alternative solution seemed way too complex imo.

I also verified locally that the fix is working (api response and in personal times popup):

<img width="465" height="492" alt="fix-legacy-times-sort" src="https://github.com/user-attachments/assets/e1342910-c674-43a7-ab68-e6cb339c0657" />