### PR TITLE
fix(replays): add missing attribute for shirt

### DIFF
--- a/src/api/allfinished.js
+++ b/src/api/allfinished.js
@@ -118,6 +118,7 @@ export const getTimes = async (LevelIndex, KuskiIndex, limit, LoggedIn = 0) => {
 
   if (personal) {
     attributes.push(
+      'KuskiIndex',
       'Finished',
       'BattleIndex',
       'MaxSpeed',

--- a/src/api/besttime.js
+++ b/src/api/besttime.js
@@ -106,16 +106,18 @@ const getLatest = async (KuskiIndex, limit, lev, from, to, UserId = 0) => {
       attributes: ['LevelName', 'Locked', 'Hidden', 'LongName'],
     },
   ];
+  const attributes = ['TimeIndex', 'Time', 'Driven', 'LevelIndex'];
   if (personal) {
     include.push({
       model: TimeFile,
       as: 'TimeFileData',
     });
+    attributes.push('KuskiIndex');
   }
   const query = {
     where,
     order: [['TimeIndex', 'DESC']],
-    attributes: ['TimeIndex', 'Time', 'Driven', 'LevelIndex'],
+    attributes,
     include,
     limit: parseInt(limit, 10) > 10000 ? 10000 : parseInt(limit, 10),
   };


### PR DESCRIPTION
Backend part needed for https://github.com/elmadev/elmaonline-site/issues/843. The API responses were missing "KuskiIndex" which is used to construct the url to get player's shirt.

**allfinished.js change fixes the following pages:**
Level page/My times tab - replay popup
Cup/Personal tab - replay popup for times on the right

**besttime.js change fixes the following page:**
Profile/Times tab/Show only PRs - replay popup