### PR TITLE
feat(replays): display shirts for all players in merged replays

### DIFF
--- a/web/src/pages/replay/index.jsx
+++ b/web/src/pages/replay/index.jsx
@@ -174,6 +174,11 @@ const Replay = () => {
     dlLink = linkArray[linkArray.length - 1];
   }
 
+  const shirtUrls =
+    replays.length > 0
+      ? replays.map(r => `${config.dlUrl}shirt/${r.DrivenByData?.KuskiIndex}`)
+      : [`${config.dlUrl}shirt/${replay.DrivenByData?.KuskiIndex}`];
+
   return (
     <Layout t={`rec - ${replay.RecFileName}`}>
       <PlayerContainer theater={theater}>
@@ -182,9 +187,7 @@ const Replay = () => {
             <Recplayer
               rec={link}
               lev={`${config.dlUrl}level/${replay.LevelIndex}`}
-              shirt={[
-                `${config.dlUrl}shirt/${replay.DrivenByData?.KuskiIndex}`,
-              ]}
+              shirt={shirtUrls}
               controls
             />
           )}


### PR DESCRIPTION
Closes https://github.com/elmadev/elmaonline-site/issues/850.

All players' custom shirts will now be displayed when manually merging replays from the replay page (normal, battle, cup replays).

Unmerged replay sends the `replay` object, merged replay sends both the `replay` and the `replays` object. The latter stores shirts for all players. The `shirt` attribute already supports arrays so everything worked right out of the box. This replay page is the only one that allows merging replays, so that's why I changed only this one. In the future once we can display both players for multiplayer or already merged recs, we can adjust the necessary components for those pages as well.

Tested locally on regular, battle and cup recs:
<img width="462" height="230" alt="merged-replay-shirts" src="https://github.com/user-attachments/assets/03078320-2792-4932-a98e-f8af508fc799" />
