### PR TITLE
feat(other): add button tooltips for lgr and level pages

### DIFF
--- a/web/src/features/LGRList/index.jsx
+++ b/web/src/features/LGRList/index.jsx
@@ -68,14 +68,14 @@ const LGRList = () => {
           style={{ alignSelf: 'center', marginRight: '12px' }}
           onChange={(ev, value) => setSettings({ sortBy: value })}
         >
-          <ToggleButton value="LGRName">
+          <ToggleButton title="Sort by name" value="LGRName">
             {settings.sortBy === 'LGRName' ? (
               <SortByAlphaIcon fontSize="small" />
             ) : (
               <SortByAlphaOutlinedIcon fontSize="small" />
             )}
           </ToggleButton>
-          <ToggleButton value="Downloads">
+          <ToggleButton title="Sort by downloads" value="Downloads">
             {settings.sortBy === 'Downloads' ? (
               <GetAppIcon fontSize="small" />
             ) : (
@@ -90,10 +90,10 @@ const LGRList = () => {
           style={{ alignSelf: 'center', marginRight: '12px' }}
           onChange={(ev, value) => setSettings({ grid: value })}
         >
-          <ToggleButton value={false}>
+          <ToggleButton title="List view" value={false}>
             <ListIcon fontSize="small" />
           </ToggleButton>
-          <ToggleButton value={true}>
+          <ToggleButton title="Thumbnail view" value={true}>
             <AppsIcon fontSize="small" />
           </ToggleButton>
         </ToggleButtonGroup>

--- a/web/src/features/LevelList/index.jsx
+++ b/web/src/features/LevelList/index.jsx
@@ -314,10 +314,10 @@ export default function LevelList({
               style={{ alignSelf: 'center', marginRight: '12px' }}
               onChange={(ev, value) => setSettings({ grid: value })}
             >
-              <ToggleButton value={false}>
+              <ToggleButton title="List view" value={false}>
                 <ListIcon fontSize="small" />
               </ToggleButton>
-              <ToggleButton value={true}>
+              <ToggleButton title="Thumbnail view" value={true}>
                 <AppsIcon fontSize="small" />
               </ToggleButton>
             </ToggleButtonGroup>


### PR DESCRIPTION
Added tooltips for sorting and toggle display buttons on the following pages:

Levels page (search tab)
Profile page (levels added tab)
LGRs page (repository tab)