### PR TITLE
fix(levelpacks): get correct replays on direct visit or refresh

### DIFF
--- a/web/src/pages/levelpack/index.jsx
+++ b/web/src/pages/levelpack/index.jsx
@@ -81,7 +81,7 @@ const LevelPack = () => {
     }
   }, [showLegacy]);
 
-  if (!isRehydrated || !levelPackInfo)
+  if (!isRehydrated || !levelPackInfo.LevelPackIndex)
     return (
       <Layout edge t={`Level pack - ${name}`}>
         <Loading />


### PR DESCRIPTION
Fixes https://github.com/elmadev/elmaonline-site/issues/767.

The issue was that the `levelPackInfo` was true even when it existed only as an empty object. The api request was then calling `api/replay?page=0&pageSize=25&order=desc&levelPack=0` because we didn't have LevelPackIndex yet.

Tested both direct page visit and page refresh in the Replay tab and the replays are correctly filtered for the levpack now. I haven't observed any differences in page load.