### PR TITLE
feat(teams): sort teams and team members alphabetically

### DIFF
--- a/api/src/api/teams.js
+++ b/api/src/api/teams.js
@@ -4,13 +4,14 @@ import { Team, Kuski } from '#data/models';
 const router = express.Router();
 
 const getTeams = async () => {
-  const data = await Team.findAll({});
+  const data = await Team.findAll({ order: [['Team', 'ASC']] });
   return data;
 };
 
 const GetMembers = async t => {
   const data = await Team.findOne({
     where: { Team: t },
+    order: [[{ model: Kuski, as: 'Members' }, 'Kuski', 'ASC']],
     include: [
       {
         model: Kuski,


### PR DESCRIPTION
Closes https://github.com/elmadev/elmaonline-site/issues/855.

For sorting by the "Kuski" attribute from the associated aliased model we can choose either the name of the association:
`order: [['Members', 'Kuski', 'ASC']],`

or the more explicit simple association object:
`order: [[{ model: Kuski, as: 'Members' }, 'Kuski', 'ASC']],`

I have picked the latter for more clarity. Both is documented over at https://sequelize.org/docs/v6/core-concepts/model-querying-basics/#ordering.

Tested changes locally and both teams and team members are now sorted alphabetically.